### PR TITLE
Bugfix: Creating new encrypted file throws exception

### DIFF
--- a/JsonFlatFileDataStore.Test/DataStoreTests.cs
+++ b/JsonFlatFileDataStore.Test/DataStoreTests.cs
@@ -472,6 +472,22 @@ namespace JsonFlatFileDataStore.Test
             UTHelpers.Down(path);
         }
 
+        [Fact]
+        public void FileNotFound_CreateNewFile_Encrypted()
+        {
+            var path = UTHelpers.GetFullFilePath($"CreateNewFile_Encrypted_{DateTime.UtcNow.Ticks}");
+
+            var storeFileNotFound = new DataStore(path, encryptionKey:"53cr3t");
+            var collectionKeys = storeFileNotFound.GetKeys();
+            Assert.Equal(0, collectionKeys.Count);
+
+            var storeFileFound = new DataStore(path, encryptionKey: "53cr3t");
+            var collectionKeysFileFound = storeFileNotFound.GetKeys();
+            Assert.Equal(0, collectionKeysFileFound.Count);
+
+            UTHelpers.Down(path);
+        }
+
         public class Employee
         {
             public int Id { get; set; }

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -474,7 +474,7 @@ namespace JsonFlatFileDataStore
                 catch (FileNotFoundException)
                 {
                     File.WriteAllText(path, _encryptJson(json));
-                    break;
+                    return json;
                 }
                 catch (IOException e) when (e.Message.Contains("because it is being used by another process"))
                 {

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -473,8 +473,9 @@ namespace JsonFlatFileDataStore
                 }
                 catch (FileNotFoundException)
                 {
-                    File.WriteAllText(path, _encryptJson(json));
-                    return json;
+                    json = _encryptJson(json);
+                    File.WriteAllText(path, json);
+                    break;
                 }
                 catch (IOException e) when (e.Message.Contains("because it is being used by another process"))
                 {


### PR DESCRIPTION
When you try to create a new encrypted file that doesn't exist, an exception is thrown. This is due to the fact that the `ReadJsonFromFile` function tries to "decrypt" the pure json string "{}" at the end instead of the base64.

So after creating the encrypted file you can just return the "{}" which is expected by the calling function.