### PR TITLE
ci: replace Travis and AppVeyor with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          '6.0.302'
-          '6.x'
+          6.0.302
+          6.x
     - name: Restore
       run: dotnet restore
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      Solution_name: JsonFlatFileDataStore.sln
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          '6.0.302'
+          '6.x'
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build
+    - name: Tests
+      run: dotnet test JsonFlatFileDataStore.Test/JsonFlatFileDataStore.Test.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,10 +1,6 @@
 name: CI_WIN
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push]
 
 jobs:
   build-windows:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI_WIN
 
 on:
   push:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    env:
+      Solution_name: JsonFlatFileDataStore.sln
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          6.0.302
+          6.x
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build
+    - name: Tests
+      run: dotnet test JsonFlatFileDataStore.Test/JsonFlatFileDataStore.Test.csproj

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ JSON Flat File Data Store
 |-------------|----------------|-------------|
 | AppVeyor    | Windows        |[![Build status](https://ci.appveyor.com/api/projects/status/adq9as6ruraln8tn?svg=true&branch=master)](https://ci.appveyor.com/project/ttu/json-flatfile-datastore)|
 | Travis      | Linux / macOS  |[![Build Status](https://api.travis-ci.com/ttu/json-flatfile-datastore.svg?branch=master)](https://app.travis-ci.com/ttu/json-flatfile-datastore)|
+| GH Actions  | Linux          |[![Build Status](https://github.com/ttu/json-flatfile-datastore/actions/workflows/ci.yml/badge.svg?branch=master)]
 
 Simple data store that saves the data in JSON format to a single file.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ JSON Flat File Data Store
 | AppVeyor    | Windows        |[![Build status](https://ci.appveyor.com/api/projects/status/adq9as6ruraln8tn?svg=true&branch=master)](https://ci.appveyor.com/project/ttu/json-flatfile-datastore)|
 | Travis      | Linux / macOS  |[![Build Status](https://api.travis-ci.com/ttu/json-flatfile-datastore.svg?branch=master)](https://app.travis-ci.com/ttu/json-flatfile-datastore)|
 | GH Actions  | Linux          |[![Build Status](https://github.com/ttu/json-flatfile-datastore/actions/workflows/ci.yml/badge.svg?branch=master)]
-
+| GH Actions  | Windows        |[![Build Status](https://github.com/ttu/json-flatfile-datastore/actions/workflows/ci_win.yml/badge.svg?branch=master)]
 Simple data store that saves the data in JSON format to a single file.
 
 * Small API with basic functionality that is needed for handling data


### PR DESCRIPTION
- [x] Use Actions
- [x] Update `README` for build status
- [x] Use Actions for Windows build

See example from
https://github.com/shusso/json-flatfile-datastore/pull/1
<img width="920" alt="Screenshot 2023-04-15 at 11 00 47" src="https://user-images.githubusercontent.com/590002/232198535-96b2576b-e3e9-4ed0-9c62-5a5049237e8f.png">

