### PR TITLE
feat: replace Newtonsoft.Json with System.Text.Json

### DIFF
--- a/JsonFlatFileDataStore.Benchmark/Program.cs
+++ b/JsonFlatFileDataStore.Benchmark/Program.cs
@@ -6,10 +6,10 @@ internal class Program
     {
         var switcher = new BenchmarkSwitcher(new[]
         {
-                typeof(TypedCollectionBenchmark),
-                typeof(DynamicCollectionBenchmark),
-                typeof(ObjectExtensionsBenchmark)
-            });
+            typeof(TypedCollectionBenchmark),
+            typeof(DynamicCollectionBenchmark),
+            typeof(ObjectExtensionsBenchmark)
+        });
 
         switcher.Run(args);
     }

--- a/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
+++ b/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
@@ -1,5 +1,4 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -117,7 +116,7 @@ public class BehaviorPinningTests
     {
         public int Id { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public StatusValue Status { get; set; }
     }
 }

--- a/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
+++ b/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace JsonFlatFileDataStore.Test;
 

--- a/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
+++ b/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace JsonFlatFileDataStore.Test;
 

--- a/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
+++ b/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Text.Json.Nodes;
 
 namespace JsonFlatFileDataStore.Test;

--- a/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
+++ b/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
-using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -84,12 +83,11 @@ public class CaseSensitivityTests
 
         // The existing "User" collection must be updated in place, not shadowed by a second
         // camelCased "user" key. A JSON object with two keys differing only by case is corrupt.
-        var root = JObject.Parse(File.ReadAllText(path));
-        var userKeys = root.Properties()
-                           .Where(p => string.Equals(p.Name, "user", StringComparison.OrdinalIgnoreCase))
+        var root = JsonNode.Parse(File.ReadAllText(path)).AsObject();
+        var userKeys = root.Where(p => string.Equals(p.Key, "user", StringComparison.OrdinalIgnoreCase))
                            .ToList();
         Assert.Single(userKeys);
-        Assert.Equal(2, userKeys[0].Value.Count());
+        Assert.Equal(2, userKeys[0].Value.AsArray().Count);
 
         // Reopening finds both items through the collection API.
         var store2 = new DataStore(path, useLowerCamelCase: true);

--- a/JsonFlatFileDataStore.Test/CollectionModificationTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionModificationTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Dynamic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using System.Dynamic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -142,7 +142,7 @@ public class CollectionModificationTests
 
         var collection2 = store2.GetCollection<User>("users2");
         await collection2.UpdateOneAsync(x => x.Id == 0, new { name = "new value" });
-        await collection2.UpdateOneAsync(x => x.Id == 1, JToken.Parse("{ name: \"new value 2\"} "));
+        await collection2.UpdateOneAsync(x => x.Id == 1, JsonNode.Parse("{ \"name\": \"new value 2\"} "));
 
         var store3 = new DataStore(newFilePath);
 
@@ -203,9 +203,9 @@ public class CollectionModificationTests
             Id = Guid.NewGuid().ToString(),
             Type = "empty",
             Fragments = new List<string>
-                {
-                    Guid.NewGuid().ToString()
-                }
+            {
+                Guid.NewGuid().ToString()
+            }
         };
 
         var insertResult = collection.InsertOne(newModel);
@@ -220,10 +220,10 @@ public class CollectionModificationTests
         {
             Type = "filled",
             Fragments = new List<string>
-                {
-                    Guid.NewGuid().ToString(),
-                    Guid.NewGuid().ToString()
-                }
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            }
         };
 
         await collection2.UpdateOneAsync(e => e.Id == newModel.Id, updateData);
@@ -254,9 +254,9 @@ public class CollectionModificationTests
             Id = Guid.NewGuid().ToString(),
             Type = "empty",
             Fragments = new List<int>
-                {
-                    1
-                }
+            {
+                1
+            }
         };
 
         var insertResult = collection.InsertOne(newModel);
@@ -271,10 +271,10 @@ public class CollectionModificationTests
         {
             Type = "filled",
             Fragments = new List<int>
-                {
-                    2,
-                    3
-                }
+            {
+                2,
+                3
+            }
         };
 
         await collection2.UpdateOneAsync(e => e.Id == newModel.Id, updateData);
@@ -319,10 +319,10 @@ public class CollectionModificationTests
         {
             Type = "filled",
             NestedLists = new List<List<int>>
-                {
-                    null,
-                    new List<int> { 4 },
-                }
+            {
+                null,
+                new List<int> { 4 },
+            }
         };
 
         await collection2.UpdateOneAsync(e => e.Id == newModel.Id, updateData);
@@ -407,10 +407,10 @@ public class CollectionModificationTests
 
         var newUsers = new[]
         {
-                new { id = 20, name = "A1", age = 55 },
-                new { id = 21, name = "A2", age = 55 },
-                new { id = 22, name = "A3", age = 55 }
-            };
+            new { id = 20, name = "A1", age = 55 },
+            new { id = 21, name = "A2", age = 55 },
+            new { id = 22, name = "A3", age = 55 }
+        };
 
         await collection.InsertManyAsync(newUsers);
 
@@ -445,19 +445,20 @@ public class CollectionModificationTests
         Assert.Equal(3, collection.Count);
 
         var newUsersJson = @"
-            [
-                { 'id': 20, 'name': 'A1', 'age': 55 },
-                { 'id': 21, 'name': 'A2', 'age': 55 },
-                { 'id': 22, 'name': 'A3', 'age': 55 }
-            ]
-            ";
+        [
+            { ""id"": 20, ""name"": ""A1"", ""age"": 55 },
+            { ""id"": 21, ""name"": ""A2"", ""age"": 55 },
+            { ""id"": 22, ""name"": ""A3"", ""age"": 55 }
+        ]
+        ";
 
-        var newUsers = JToken.Parse(newUsersJson);
+        var newUsersArray = JsonNode.Parse(newUsersJson).AsArray();
+        var newUsers = newUsersArray.Select(n => n as dynamic);
 
         await collection.InsertManyAsync(newUsers);
 
-        var newUserJson = "{ 'id': 23, 'name': 'A4', 'age': 22 }";
-        var newUser = JToken.Parse(newUserJson);
+        var newUserJson = "{ \"id\": 23, \"name\": \"A4\", \"age\": 22 }";
+        var newUser = JsonNode.Parse(newUserJson);
 
         await collection.InsertOneAsync(newUser);
 
@@ -494,10 +495,10 @@ public class CollectionModificationTests
 
         var newUsers = new[]
         {
-                new User { Id = 20, Name = "A1", Age = 55 },
-                new User { Id = 21, Name = "A2", Age = 55 },
-                new User { Id = 22, Name = "A3", Age = 55 }
-            };
+            new User { Id = 20, Name = "A1", Age = 55 },
+            new User { Id = 21, Name = "A2", Age = 55 },
+            new User { Id = 22, Name = "A3", Age = 55 }
+        };
 
         collection.InsertMany(newUsers);
 
@@ -623,7 +624,7 @@ public class CollectionModificationTests
         var collection = store.GetCollection("sensor");
 
         var success = collection.ReplaceOne(e => e.id == 11,
-            JToken.Parse("{ 'id': 11, 'mac': 'F4:A5:74:89:16:57', 'data': { 'temperature': 20.5 } }"),
+            JsonNode.Parse("{ \"id\": 11, \"mac\": \"F4:A5:74:89:16:57\", \"data\": { \"temperature\": 20.5 } }"),
             true);
         Assert.True(success);
 
@@ -884,13 +885,14 @@ public class CollectionModificationTests
         collection.InsertOne(user);
 
         var patchData = new Dictionary<string, object>
-            {
-                { "Age", 41 },
-                { "name", "James" },
-                { "Work", new Dictionary<string, object> { { "Name", "ACME" } } }
-            };
-        var jobject = JObject.FromObject(patchData);
-        dynamic patchExpando = JsonConvert.DeserializeObject<ExpandoObject>(jobject.ToString());
+        {
+            { "Age", 41 },
+            { "name", "James" },
+            { "Work", new Dictionary<string, object> { { "Name", "ACME" } } }
+        };
+        var jsonString = JsonSerializer.Serialize(patchData);
+        var options = new JsonSerializerOptions { Converters = { new SystemExpandoObjectConverter() } };
+        dynamic patchExpando = JsonSerializer.Deserialize<ExpandoObject>(jsonString, options);
 
         collection.UpdateOne(i => i.Id == 4, patchExpando as object);
 
@@ -1043,25 +1045,29 @@ public class CollectionModificationTests
 
         var collection = store.GetCollection("employee");
 
-        var ja = new JArray { "Hello World!" };
-
-        var jObj = new JObject()
+        var data = new
         {
-            ["custom_id"] = 11,
-            ["nestedArray"] = new JArray { ja },
+            custom_id = 11,
+            nestedArray = new[]
+            {
+                new[] { "Hello World!" }
+            }
         };
 
-        await collection.InsertOneAsync(jObj);
+        await collection.InsertOneAsync(data);
 
         var original = collection.Find(e => e.custom_id == 11).First();
         Assert.Equal(0, original.id);
         Assert.Equal(11, original.custom_id);
         Assert.Equal("Hello World!", original.nestedArray[0][0]);
 
-        var update = new JObject()
+        var update = new
         {
-            ["custom_id"] = 12,
-            ["nestedArray"] = new JArray { new JArray { "Other text" } },
+            custom_id = 12,
+            nestedArray = new[]
+            {
+                new[] { "Other text" }
+            }
         };
 
         await collection.UpdateOneAsync(e => e.custom_id == 11, update);

--- a/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Text.Json.Nodes;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -132,22 +132,22 @@ public class CollectionQueryTests
         var collection = store.GetCollection("collectionWithStringId");
 
         // Insert seed value with upsert
-        collection.ReplaceOne(e => e, JToken.Parse("{ 'myId': 'test1' }"), true);
+        collection.ReplaceOne(e => e, JsonNode.Parse("{ \"myId\": \"test1\" }"), true);
 
         var nextId = collection.GetNextIdValue();
         Assert.Equal("test2", nextId);
 
-        var nextUpdate = JToken.Parse("{ 'myId': 'somethingWrong2' }");
+        var nextUpdate = JsonNode.Parse("{ \"myId\": \"somethingWrong2\" }");
         collection.InsertOne(nextUpdate);
-        Assert.Equal(nextId, nextUpdate["myId"]);
+        Assert.Equal(nextId, nextUpdate["myId"].ToString());
 
         nextId = collection.GetNextIdValue();
         Assert.Equal("test3", nextId);
 
-        nextUpdate = JToken.Parse("{ 'xxx': 111 }");
+        nextUpdate = JsonNode.Parse("{ \"xxx\": 111 }");
         collection.InsertOne(nextUpdate);
-        Assert.Equal(nextId, nextUpdate["myId"]);
-        Assert.Equal(111, nextUpdate["xxx"]);
+        Assert.Equal(nextId, nextUpdate["myId"].GetValue<string>());
+        Assert.Equal(111, nextUpdate["xxx"].GetValue<int>());
 
         nextId = collection.GetNextIdValue();
         Assert.Equal("test4", nextId);

--- a/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
@@ -123,7 +123,7 @@ public class CollectionQueryTests
     }
 
     [Fact]
-    public void GetNextIdValue_StringType_JToken()
+    public void GetNextIdValue_StringType_JsonNode()
     {
         var newFilePath = UTHelpers.Up();
 

--- a/JsonFlatFileDataStore.Test/CopyPropertiesTests.cs
+++ b/JsonFlatFileDataStore.Test/CopyPropertiesTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using Xunit;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -73,10 +73,10 @@ public class CopyPropertiesTests
         var family = new Family
         {
             Parents = new List<Parent>
-                {
-                    new Parent { Name = "Jim", Age = 52 },
-                    new Parent { Name = "Theodor", Age = 14 }
-                },
+            {
+                new Parent { Name = "Jim", Age = 52 },
+                new Parent { Name = "Theodor", Age = 14 }
+            },
             Address = new Address { City = "Helsinki" }
         };
 
@@ -123,10 +123,10 @@ public class CopyPropertiesTests
         sParent.Age = 14;
 
         family.Parents = new List<ExpandoObject>
-            {
-                fParent,
-                sParent,
-            };
+        {
+            fParent,
+            sParent,
+        };
 
         family.Address = new ExpandoObject();
         family.Address.City = "Helsinki";
@@ -228,9 +228,9 @@ public class CopyPropertiesTests
         var family = new Family
         {
             Parents = new List<Parent>
-                {
-                    new Parent { Name = "Jim", Age = 52 }
-                },
+            {
+                new Parent { Name = "Jim", Age = 52 }
+            },
             Address = new Address { City = "Helsinki" }
         };
 
@@ -251,13 +251,14 @@ public class CopyPropertiesTests
         user.work = work;
 
         var patchData = new Dictionary<string, object>
-            {
-                { "age", 41 },
-                { "name", "James" },
-                { "work", new Dictionary<string, object> { { "name", "ACME" } } }
-            };
-        var jobject = JObject.FromObject(patchData);
-        dynamic patchExpando = JsonConvert.DeserializeObject<ExpandoObject>(jobject.ToString());
+        {
+            { "age", 41 },
+            { "name", "James" },
+            { "work", new Dictionary<string, object> { { "name", "ACME" } } }
+        };
+        var jsonString = JsonSerializer.Serialize(patchData);
+        var options = new JsonSerializerOptions { Converters = { new SystemExpandoObjectConverter() } };
+        dynamic patchExpando = JsonSerializer.Deserialize<ExpandoObject>(jsonString, options);
 
         ObjectExtensions.CopyProperties(patchExpando, user);
         Assert.Equal("James", user.name);
@@ -296,10 +297,10 @@ public class CopyPropertiesTests
         sensor.mac = "F4:A5:74:89:16:57";
         sensor.timestamp = null;
         sensor.data = new Dictionary<string, object>
-            {
-                { "temperature", 24.3 },
-                { "identifier", null }
-            };
+        {
+            { "temperature", 24.3 },
+            { "identifier", null }
+        };
 
         ObjectExtensions.CopyProperties(sensor, destination);
 
@@ -319,13 +320,14 @@ public class CopyPropertiesTests
         };
 
         var patchData = new Dictionary<string, object>
-            {
-                { "Age", 41 },
-                { "Name", "James" },
-                { "Work", new Dictionary<string, object> { { "Name", "ACME" } } }
-            };
-        var jobject = JObject.FromObject(patchData);
-        dynamic patchExpando = JsonConvert.DeserializeObject<ExpandoObject>(jobject.ToString());
+        {
+            { "Age", 41 },
+            { "Name", "James" },
+            { "Work", new Dictionary<string, object> { { "Name", "ACME" } } }
+        };
+        var jsonString = JsonSerializer.Serialize(patchData);
+        var options = new JsonSerializerOptions { Converters = { new SystemExpandoObjectConverter() } };
+        dynamic patchExpando = JsonSerializer.Deserialize<ExpandoObject>(jsonString, options);
 
         ObjectExtensions.CopyProperties(patchExpando, user);
         Assert.Equal("James", user.Name);

--- a/JsonFlatFileDataStore.Test/DataStoreTests.cs
+++ b/JsonFlatFileDataStore.Test/DataStoreTests.cs
@@ -1,7 +1,10 @@
 ﻿using System.Dynamic;
 using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
 using NSubstitute;
 
 namespace JsonFlatFileDataStore.Test;
@@ -15,7 +18,7 @@ public class DataStoreTests
 
         var store = new DataStore(newFilePath);
 
-        store.UpdateAll("{ 'tasks': [ { 'id': 0, 'task': 'Commit'} ] }");
+        store.UpdateAll("{ \"tasks\": [ { \"id\": 0, \"task\": \"Commit\"} ] }");
 
         var collection = store.GetCollection("tasks");
         Assert.Equal(1, collection.Count);
@@ -182,7 +185,7 @@ public class DataStoreTests
         };
 
         // Example with JSON object
-        var employeeJson = JToken.Parse("{ 'id': 2, 'name': 'Raymond', 'age': 32 }");
+        var employeeJson = JsonNode.Parse("{ \"id\": 2, \"name\": \"Raymond\", \"age\": 32 }");
 
         // Example with JSON object
         var employeeDict = new Dictionary<string, object>
@@ -208,7 +211,7 @@ public class DataStoreTests
         var updateData = new { name = "John Doe" };
         await collection.UpdateOneAsync(e => e.id == employee.id, updateData);
 
-        var updateJson = JObject.Parse("{ 'name': 'Raymond Doe' }");
+        var updateJson = JsonNode.Parse("{ \"name\": \"Raymond Doe\" }");
         await collection.UpdateOneAsync(e => e.id == 1, updateJson);
 
         var updateDict = new Dictionary<string, object> { ["name"] = "Andy Doe" };
@@ -243,7 +246,7 @@ public class DataStoreTests
         };
 
         // Example with JSON object
-        var employeeJson = JToken.Parse("{ 'id': 200, 'name': 'Raymond', 'age': 32 }");
+        var employeeJson = JsonNode.Parse("{ \"id\": 200, \"name\": \"Raymond\", \"age\": 32 }");
 
         // Example with JSON object
         var employeeDict = new Dictionary<string, object>
@@ -266,7 +269,7 @@ public class DataStoreTests
         await collection.InsertOneAsync(employeeExpando);
 
         Assert.Equal(20, employee.id);
-        Assert.Equal(21, employeeJson["id"]);
+        Assert.Equal(21, employeeJson["id"].GetValue<int>());
         Assert.Equal(22, employeeDict["id"]);
         Assert.Equal(23, ((IDictionary<string, object>)employeeExpando)["id"]);
 
@@ -290,7 +293,7 @@ public class DataStoreTests
         };
 
         // Example with JSON object
-        var employeeJson = JToken.Parse("{ 'name': 'Raymond', 'age': 32 }");
+        var employeeJson = JsonNode.Parse("{ \"name\": \"Raymond\", \"age\": 32 }");
 
         // Example with JSON object
         var employeeDict = new Dictionary<string, object>
@@ -310,7 +313,10 @@ public class DataStoreTests
         await collection.InsertOneAsync(employeeDict);
         await collection.InsertOneAsync(employeeExpando);
 
-        Assert.Equal(1, employeeJson["acc"]);
+        // System.Text.Json: JsonNode indexer returns JsonNode, requires explicit GetValue<T>()
+        // Newtonsoft.Json: JToken had implicit conversion operators, allowed direct comparison
+        Assert.Equal(1, employeeJson["acc"].GetValue<int>());
+        // Dictionary and ExpandoObject return 'object' (boxed int), which Assert.Equal handles directly
         Assert.Equal(2, employeeDict["acc"]);
         Assert.Equal(3, ((IDictionary<string, object>)employeeExpando)["acc"]);
 
@@ -335,7 +341,7 @@ public class DataStoreTests
         };
 
         // Example with JSON object
-        var employeeJson = JToken.Parse("{ 'name': 'Raymond', 'age': 32 }");
+        var employeeJson = JsonNode.Parse("{ \"name\": \"Raymond\", \"age\": 32 }");
 
         // Example with JSON object
         var employeeDict = new Dictionary<string, object>
@@ -356,7 +362,10 @@ public class DataStoreTests
         await collection.InsertOneAsync(employeeExpando);
 
         Assert.Equal("hello", employee.acc);
-        Assert.Equal("hello0", employeeJson["acc"]);
+        // System.Text.Json: JsonNode indexer returns JsonNode, requires explicit GetValue<T>()
+        // Newtonsoft.Json: JToken had implicit conversion operators, allowed direct comparison
+        Assert.Equal("hello0", employeeJson["acc"].GetValue<string>());
+        // Dictionary and ExpandoObject return 'object' (boxed string), which Assert.Equal handles directly
         Assert.Equal("hello1", employeeDict["acc"]);
         Assert.Equal("hello2", ((IDictionary<string, object>)employeeExpando)["acc"]);
 

--- a/JsonFlatFileDataStore.Test/DictionarySerializationTests.cs
+++ b/JsonFlatFileDataStore.Test/DictionarySerializationTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Tests for Dictionary serialization, especially Dictionary with non-string keys

--- a/JsonFlatFileDataStore.Test/DynamicAccessEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/DynamicAccessEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Edge cases for DataStore.GetItem when the value is an array (of objects, of arrays, mixed).

--- a/JsonFlatFileDataStore.Test/FileAccessTests.cs
+++ b/JsonFlatFileDataStore.Test/FileAccessTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 
 namespace JsonFlatFileDataStore.Test;
 

--- a/JsonFlatFileDataStore.Test/JTokenInputTests.cs
+++ b/JsonFlatFileDataStore.Test/JTokenInputTests.cs
@@ -1,24 +1,24 @@
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
-/// Pin behavior of public APIs that accept Newtonsoft JToken/JObject/JArray as input.
-/// Migration to System.Text.Json must decide: keep these as a compatibility shim
-/// or drop them as a breaking change. These tests lock the contract before that decision.
+/// Pin behavior of public APIs that accept System.Text.Json.Nodes JsonNode/JsonObject/JsonArray
+/// as input. The original tests targeted Newtonsoft's JToken/JObject/JArray; after the
+/// Newtonsoft → System.Text.Json migration the equivalent contract is exercised here.
 /// </summary>
 public class JTokenInputTests
 {
     [Fact]
-    public async Task InsertOne_JToken_AnonymousObject_RoundTrip()
+    public async Task InsertOne_JsonNode_AnonymousObject_RoundTrip()
     {
         var path = UTHelpers.GetFullFilePath($"JTInsert_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
 
-        var token = JToken.Parse("{ 'id': 1, 'name': 'Alice', 'age': 30 }");
+        var node = JsonNode.Parse("{ \"id\": 1, \"name\": \"Alice\", \"age\": 30 }");
 
         var collection = store.GetCollection("user");
-        await collection.InsertOneAsync(token);
+        await collection.InsertOneAsync(node);
 
         store.Dispose();
 
@@ -34,7 +34,7 @@ public class JTokenInputTests
     }
 
     [Fact]
-    public async Task UpdateOne_JTokenPatch_AppliesCorrectly()
+    public async Task UpdateOne_JsonNodePatch_AppliesCorrectly()
     {
         var path = UTHelpers.GetFullFilePath($"JTUpdate_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
@@ -42,7 +42,7 @@ public class JTokenInputTests
         var collection = store.GetCollection("user");
         await collection.InsertOneAsync(new { id = 1, name = "Original", age = 20, location = "NY" });
 
-        var patch = JToken.Parse("{ 'name': 'Patched', 'age': 25 }");
+        var patch = JsonNode.Parse("{ \"name\": \"Patched\", \"age\": 25 }");
         var updated = await collection.UpdateOneAsync((Predicate<dynamic>)(e => e.id == 1), patch);
         Assert.True(updated);
 
@@ -60,7 +60,7 @@ public class JTokenInputTests
     }
 
     [Fact]
-    public async Task ReplaceOne_JObject_NestedJArray()
+    public async Task ReplaceOne_JsonObject_NestedJsonArray()
     {
         var path = UTHelpers.GetFullFilePath($"JTReplace_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
@@ -68,12 +68,12 @@ public class JTokenInputTests
         var collection = store.GetCollection("things");
         await collection.InsertOneAsync(new { id = 1, label = "old", tags = new[] { "a" } });
 
-        var replacement = new JObject
+        var replacement = new JsonObject
         {
             ["id"] = 1,
             ["label"] = "new",
-            ["tags"] = new JArray { "x", "y", "z" },
-            ["nested"] = new JArray { new JArray { 1, 2 }, new JArray { 3, 4 } }
+            ["tags"] = new JsonArray("x", "y", "z"),
+            ["nested"] = new JsonArray(new JsonArray(1, 2), new JsonArray(3, 4))
         };
 
         var ok = await collection.ReplaceOneAsync((Predicate<dynamic>)(e => e.id == 1), replacement);
@@ -96,13 +96,13 @@ public class JTokenInputTests
     }
 
     [Fact]
-    public async Task InsertMany_JTokenArray_AllItemsInserted()
+    public async Task InsertMany_JsonArray_AllItemsInserted()
     {
         var path = UTHelpers.GetFullFilePath($"JTMany_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
 
-        var json = "[ { 'id': 1, 'name': 'A' }, { 'id': 2, 'name': 'B' }, { 'id': 3, 'name': 'C' } ]";
-        var array = JToken.Parse(json);
+        var json = "[ { \"id\": 1, \"name\": \"A\" }, { \"id\": 2, \"name\": \"B\" }, { \"id\": 3, \"name\": \"C\" } ]";
+        var array = (JsonArray)JsonNode.Parse(json);
 
         var collection = store.GetCollection("items");
         await collection.InsertManyAsync(array);

--- a/JsonFlatFileDataStore.Test/JsonNodeInputTests.cs
+++ b/JsonFlatFileDataStore.Test/JsonNodeInputTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -7,7 +7,7 @@ namespace JsonFlatFileDataStore.Test;
 /// as input. The original tests targeted Newtonsoft's JToken/JObject/JArray; after the
 /// Newtonsoft → System.Text.Json migration the equivalent contract is exercised here.
 /// </summary>
-public class JTokenInputTests
+public class JsonNodeInputTests
 {
     [Fact]
     public async Task InsertOne_JsonNode_AnonymousObject_RoundTrip()

--- a/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
+++ b/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace JsonFlatFileDataStore.Test;
 

--- a/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
+++ b/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
@@ -232,8 +232,9 @@ public class JsonOutputFormatTests
 
         var json = UTHelpers.GetFileContent(path);
 
-        // Newtonsoft writes 5.0, System.Text.Json writes 5 — this test catches the difference
-        Assert.Contains("5.0", json);
+        // System.Text.Json writes whole-number doubles without a trailing ".0" (e.g., 5 not 5.0).
+        // Newtonsoft.Json preserved the trailing ".0". See README "Known Differences".
+        Assert.Matches("\"rating\"\\s*:\\s*5(\\b|[^.0-9])", json);
 
         store.Dispose();
         UTHelpers.Down(path);

--- a/JsonFlatFileDataStore.Test/NullAndEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/NullAndEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Tests for null handling, empty collections, and edge cases that may differ

--- a/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Numeric edge cases that commonly differ between Newtonsoft and System.Text.Json:

--- a/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
@@ -46,13 +46,12 @@ public class NumericEdgeCaseTests
     }
 
     [Fact]
-    public async Task Decimal_LargeValue_LosesPrecision_BehaviorPinned()
+    public async Task Decimal_LargeValue_RoundTripsExactly()
     {
-        // Documented limitation of the current Newtonsoft path: very large decimal values
-        // are serialized via JObject → ExpandoObject (which uses double internally),
-        // so significant digits beyond double precision are lost on round trip.
-        // Migration note: STJ may behave differently here — expected to either round-trip
-        // exactly or fail explicitly. Update this test once the migration lands.
+        // The old Newtonsoft path serialized via JObject → ExpandoObject (which uses double
+        // internally), so significant digits beyond double precision were lost on round trip.
+        // After the System.Text.Json migration the write path preserves the decimal's raw JSON
+        // token verbatim, so large decimal values now round-trip exactly.
         var path = UTHelpers.GetFullFilePath($"DecLoss_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
 
@@ -64,8 +63,8 @@ public class NumericEdgeCaseTests
         var store2 = new DataStore(path);
         var item = store2.GetCollection<DecimalModel>("decModel").AsQueryable().First();
 
-        // Precision is lost — assert the value differs from the input.
-        Assert.NotEqual(79228162514264337593543950m, item.Price);
+        // Precision is preserved — the value round-trips exactly.
+        Assert.Equal(79228162514264337593543950m, item.Price);
 
         store2.Dispose();
         UTHelpers.Down(path);

--- a/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
+++ b/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace JsonFlatFileDataStore.Test;
 

--- a/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
+++ b/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Text.Json;
 
 namespace JsonFlatFileDataStore.Test;

--- a/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
+++ b/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Tests that validate serialization/deserialization behavior critical for

--- a/JsonFlatFileDataStore.Test/SingleItemTests.cs
+++ b/JsonFlatFileDataStore.Test/SingleItemTests.cs
@@ -75,14 +75,23 @@ public class SingleItemTests
 
         var test = DateTime.Now.ToShortDateString();
 
-        var itemDynamic = store.GetItem("myDate_string");
+        // Typed: System.Text.Json deserializes date strings to DateTime
         var itemTyped = store.GetItem<DateTime>("myDate_string");
         Assert.Equal(2009, itemTyped.Year);
 
-        var itemDynamic2 = store.GetItem("myDate_date");
+        // Dynamic: Now automatically parses date strings to DateTime (Newtonsoft.Json compatibility)
+        var itemDynamic = store.GetItem("myDate_string");
+        Assert.IsType<DateTime>(itemDynamic);
+        Assert.Equal(2009, itemDynamic.Year);
+
+        // Typed: System.Text.Json deserializes ISO date strings to DateTime
         var itemTyped2 = store.GetItem<DateTime>("myDate_date");
-        Assert.Equal(2015, itemDynamic2.Year);
         Assert.Equal(2015, itemTyped2.Year);
+
+        // Dynamic: Now automatically parses ISO date strings to DateTime (Newtonsoft.Json compatibility)
+        var itemDynamic2 = store.GetItem("myDate_date");
+        Assert.IsType<DateTime>(itemDynamic2);
+        Assert.Equal(2015, itemDynamic2.Year);
 
         UTHelpers.Down(newFilePath);
     }
@@ -489,5 +498,87 @@ public class SingleItemTests
 
         store.Dispose();
         UTHelpers.Down(path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(EncryptionPassword)]
+    public void InsertItem_ComplexTypes_VerifiesJsonElementSerialization(string encryptionPassword)
+    {
+        // This test verifies that SetJsonDataElement and RemoveJsonDataElement work correctly
+        // with Dictionary<string, JsonElement> serialization/deserialization in System.Text.Json
+        var (newFilePath, store) = InitializeFileAndStore(encryptionPassword);
+
+        // Test 1: Insert nested object
+        var nestedUser = new
+        {
+            id = 100,
+            name = "Complex User",
+            metadata = new
+            {
+                tags = new[] { "admin", "developer" },
+                settings = new Dictionary<string, object>
+                {
+                    { "theme", "dark" },
+                    { "notifications", true },
+                    { "maxItems", 50 }
+                }
+            }
+        };
+
+        var result1 = store.InsertItem("complexUser", nestedUser);
+        Assert.True(result1);
+
+        var retrieved1 = store.GetItem("complexUser");
+        Assert.Equal("Complex User", retrieved1.name);
+        Assert.Equal("admin", retrieved1.metadata.tags[0]);
+        Assert.Equal("dark", retrieved1.metadata.settings.theme);
+        Assert.True(retrieved1.metadata.settings.notifications);
+
+        // Test 2: Insert array
+        var arrayData = new[] { 1, 2, 3, 4, 5 };
+        var result2 = store.InsertItem("numbers", arrayData);
+        Assert.True(result2);
+
+        var retrieved2 = store.GetItem("numbers");
+        Assert.Equal(5, retrieved2.Count);
+        Assert.Equal(3, (int)retrieved2[2]);
+
+        // Test 3: Insert mixed type object
+        var mixedData = new
+        {
+            stringVal = "test",
+            intVal = 42,
+            doubleVal = 3.14,
+            boolVal = true,
+            nullVal = (string)null,
+            dateVal = new DateTime(2023, 1, 15)
+        };
+
+        var result3 = store.InsertItem("mixedTypes", mixedData);
+        Assert.True(result3);
+
+        var retrieved3 = store.GetItem("mixedTypes");
+        Assert.Equal("test", retrieved3.stringVal);
+        Assert.Equal(42, retrieved3.intVal);
+        Assert.Equal(3.14, (double)retrieved3.doubleVal);
+        Assert.True(retrieved3.boolVal);
+        Assert.Null(retrieved3.nullVal);
+        Assert.Equal(2023, ((DateTime)retrieved3.dateVal).Year);
+
+        // Test 4: Delete items (tests RemoveJsonDataElement)
+        var deleteResult1 = store.DeleteItem("complexUser");
+        Assert.True(deleteResult1);
+        Assert.Null(store.GetItem("complexUser"));
+
+        var deleteResult2 = store.DeleteItem("numbers");
+        Assert.True(deleteResult2);
+        Assert.Null(store.GetItem("numbers"));
+
+        var deleteResult3 = store.DeleteItem("mixedTypes");
+        Assert.True(deleteResult3);
+        Assert.Null(store.GetItem("mixedTypes"));
+
+        UTHelpers.Down(newFilePath);
     }
 }

--- a/JsonFlatFileDataStore.Test/SingleItemTests.cs
+++ b/JsonFlatFileDataStore.Test/SingleItemTests.cs
@@ -73,22 +73,23 @@ public class SingleItemTests
     {
         var (newFilePath, store) = InitializeFileAndStore(encryptionPassword);
 
-        var test = DateTime.Now.ToShortDateString();
-
-        // Typed: System.Text.Json deserializes date strings to DateTime
+        // Typed reads obey the declared type: a DateTime target parses even a locale-ambiguous,
+        // non-ISO value like "6/15/2009" (via NewtonsoftDateTimeConverter's permissive fallback).
         var itemTyped = store.GetItem<DateTime>("myDate_string");
         Assert.Equal(2009, itemTyped.Year);
 
-        // Dynamic: Now automatically parses date strings to DateTime (Newtonsoft.Json compatibility)
+        // Dynamic reads only *guess* dates, and the guess is strict and invariant-culture: it matches
+        // explicit ISO 8601 formats only. "6/15/2009" is left as a string, consistent with the
+        // collection dynamic path (GetCollection) and independent of the machine's locale.
         var itemDynamic = store.GetItem("myDate_string");
-        Assert.IsType<DateTime>(itemDynamic);
-        Assert.Equal(2009, itemDynamic.Year);
+        Assert.IsType<string>(itemDynamic);
+        Assert.Equal("6/15/2009", itemDynamic);
 
         // Typed: System.Text.Json deserializes ISO date strings to DateTime
         var itemTyped2 = store.GetItem<DateTime>("myDate_date");
         Assert.Equal(2015, itemTyped2.Year);
 
-        // Dynamic: Now automatically parses ISO date strings to DateTime (Newtonsoft.Json compatibility)
+        // Dynamic: ISO 8601 strings are recognized as dates by the strict heuristic.
         var itemDynamic2 = store.GetItem("myDate_date");
         Assert.IsType<DateTime>(itemDynamic2);
         Assert.Equal(2015, itemDynamic2.Year);

--- a/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
+++ b/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
@@ -1,4 +1,4 @@
-namespace JsonFlatFileDataStore.Test;
+﻿namespace JsonFlatFileDataStore.Test;
 
 /// <summary>
 /// Round-trip tests for temporal types (DateTimeOffset, TimeSpan, DateTime.Kind)

--- a/JsonFlatFileDataStore/CommitActionHandler.cs
+++ b/JsonFlatFileDataStore/CommitActionHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using Newtonsoft.Json.Linq;
 
 namespace JsonFlatFileDataStore;
 
@@ -42,7 +41,9 @@ internal static class CommitActionHandler
 
             foreach (var action in batch)
             {
-                var (actionSuccess, updatedJson) = action.HandleAction(JObject.Parse(jsonText));
+                using var jsonDocument = JsonDocument.Parse(jsonText);
+                var rootElement = jsonDocument.RootElement.Clone();
+                var (actionSuccess, updatedJson) = action.HandleAction(rootElement);
 
                 callbacks.Enqueue((action, actionSuccess));
 

--- a/JsonFlatFileDataStore/CommitActionHandler.cs
+++ b/JsonFlatFileDataStore/CommitActionHandler.cs
@@ -39,28 +39,42 @@ internal static class CommitActionHandler
 
             var jsonText = getLatestJson();
 
+            Exception actionException = null;
+
             foreach (var action in batch)
             {
-                using var jsonDocument = JsonDocument.Parse(jsonText);
-                var rootElement = jsonDocument.RootElement.Clone();
-                var (actionSuccess, updatedJson) = action.HandleAction(rootElement);
+                try
+                {
+                    using var jsonDocument = JsonDocument.Parse(jsonText);
+                    var rootElement = jsonDocument.RootElement.Clone();
+                    var (actionSuccess, updatedJson) = action.HandleAction(rootElement);
 
-                callbacks.Enqueue((action, actionSuccess));
+                    callbacks.Enqueue((action, actionSuccess));
 
-                if (actionSuccess)
-                    jsonText = updatedJson;
+                    if (actionSuccess)
+                        jsonText = updatedJson;
+                }
+                catch (Exception e)
+                {
+                    // Record the failure but keep draining the batch so every caller's Ready
+                    // callback fires — otherwise InnerCommit's wait loop would hang forever.
+                    actionException = e;
+                    callbacks.Enqueue((action, false));
+                }
             }
 
             var updateSuccess = false;
-            Exception actionException = null;
 
-            try
+            if (actionException == null)
             {
-                updateSuccess = updateState(jsonText);
-            }
-            catch (Exception e)
-            {
-                actionException = e;
+                try
+                {
+                    updateSuccess = updateState(jsonText);
+                }
+                catch (Exception e)
+                {
+                    actionException = e;
+                }
             }
 
             foreach (var (cbAction, cbSuccess) in callbacks)

--- a/JsonFlatFileDataStore/CommitActionHandler.cs
+++ b/JsonFlatFileDataStore/CommitActionHandler.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using Newtonsoft.Json.Linq;
 
 namespace JsonFlatFileDataStore;
 
@@ -47,7 +45,9 @@ internal static class CommitActionHandler
             {
                 try
                 {
-                    var (actionSuccess, updatedJson) = action.HandleAction(JObject.Parse(jsonText));
+                    using var jsonDocument = JsonDocument.Parse(jsonText);
+                    var rootElement = jsonDocument.RootElement.Clone();
+                    var (actionSuccess, updatedJson) = action.HandleAction(rootElement);
 
                     callbacks.Enqueue((action, actionSuccess));
 

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -3,12 +3,9 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace JsonFlatFileDataStore;
 
@@ -17,19 +14,23 @@ public class DataStore : IDataStore
     private readonly string _filePath;
     private readonly string _keyProperty;
     private readonly bool _reloadBeforeGetCollection;
-    private readonly Func<JObject, string> _toJsonFunc;
+    private readonly Func<JsonElement, string> _toJsonFunc;
     private readonly Func<string, string> _convertPathToCorrectCamelCase;
     private readonly BlockingCollection<CommitAction> _updates = new BlockingCollection<CommitAction>();
     private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-    private readonly ExpandoObjectConverter _converter = new ExpandoObjectConverter();
+    private readonly JsonSerializerOptions _options = new JsonSerializerOptions
+    {
+        Converters = { new NewtonsoftDateTimeConverter(), new SystemExpandoObjectConverter() },
+        PropertyNameCaseInsensitive = true
+    };
 
-    private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings()
-    { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+    private readonly JsonSerializerOptions _serializerOptions;
 
     private readonly Func<string, string> _encryptJson;
     private readonly Func<string, string> _decryptJson;
 
-    private JObject _jsonData;
+    private JsonDocument _jsonData;
+    private readonly object _jsonDataLock = new object();
     private bool _executingJsonUpdate;
 
     public DataStore(string path, bool useLowerCamelCase = true, string keyProperty = null, bool reloadBeforeGetCollection = false,
@@ -38,17 +39,28 @@ public class DataStore : IDataStore
         _filePath = path;
 
         var useEncryption = !string.IsNullOrWhiteSpace(encryptionKey);
-        var usedFormatting = minifyJson || useEncryption ? Formatting.None : Formatting.Indented;
+        var writeIntended = !minifyJson && !useEncryption;  // Set to `true` if not minifying or encrypting
+
+        _serializerOptions = useLowerCamelCase ? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = writeIntended
+        } : new JsonSerializerOptions
+        {
+            WriteIndented = writeIntended
+        };
 
         _toJsonFunc = useLowerCamelCase
-            ? new Func<JObject, string>(data =>
+            ? new Func<JsonElement, string>(data =>
             {
-                // Serializing JObject ignores SerializerSettings, so we have to first deserialize to ExpandoObject and then serialize
-                // http://json.codeplex.com/workitem/23853
-                var jObject = JsonConvert.DeserializeObject<ExpandoObject>(data.ToString());
-                return JsonConvert.SerializeObject(jObject, usedFormatting, _serializerSettings);
+                // Deserialize to ExpandoObject to allow flexible serialization settings
+                var expandoObject = JsonSerializer.Deserialize<ExpandoObject>(data.GetRawText(), _options);
+
+                // Serialize back to JSON with camel casing and indentation options applied
+                // Case-insensitive property matching is handled in ObjectExtensions.CopyProperties
+                return JsonSerializer.Serialize(expandoObject, _serializerOptions);
             })
-            : (s => s.ToString(usedFormatting));
+            : (s => JsonSerializer.Serialize(s, _serializerOptions));
 
         _convertPathToCorrectCamelCase = useLowerCamelCase
             ? new Func<string, string>(s => string.Concat(s.Select((x, i) => i == 0 ? char.ToLower(x).ToString() : x.ToString())))
@@ -70,7 +82,7 @@ public class DataStore : IDataStore
             _decryptJson = (json => json);
         }
 
-        _jsonData = GetJsonObjectFromFile();
+        SetJsonData(GetJsonObjectFromFile());
 
         // Run updates on a background thread and use BlockingCollection to prevent multiple updates to run simultaneously
         Task.Run(() =>
@@ -80,9 +92,9 @@ public class DataStore : IDataStore
                 executionState => _executingJsonUpdate = executionState,
                 jsonText =>
                 {
-                    lock (_jsonData)
+                    lock (_jsonDataLock)
                     {
-                        _jsonData = JObject.Parse(jsonText);
+                        SetJsonData(Parse(jsonText));
                     }
 
                     return FileAccess.WriteJsonToFile(_filePath, _encryptJson, jsonText);
@@ -102,15 +114,20 @@ public class DataStore : IDataStore
         {
             _cts.Cancel();
         }
+
+        // Dispose the JsonDocument to free unmanaged resources
+        _jsonData?.Dispose();
     }
+
+
 
     public bool IsUpdating => _updates.Count > 0 || _executingJsonUpdate;
 
     public void UpdateAll(string jsonData)
     {
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            _jsonData = JObject.Parse(jsonData);
+            SetJsonData(Parse(jsonData));
         }
 
         FileAccess.WriteJsonToFile(_filePath, _encryptJson, jsonData);
@@ -118,9 +135,9 @@ public class DataStore : IDataStore
 
     public void Reload()
     {
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
     }
 
@@ -129,12 +146,12 @@ public class DataStore : IDataStore
         if (_reloadBeforeGetCollection)
         {
             // This might be a bad idea especially if the file is in use, as this can take a long time
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
 
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        var token = _jsonData[convertedKey];
+        var token = TryGetElement(_jsonData.RootElement, convertedKey);
 
         if (token == null)
         {
@@ -146,7 +163,7 @@ public class DataStore : IDataStore
             throw new KeyNotFoundException();
         }
 
-        return token.ToObject<T>();
+        return ConvertJsonElementToObject<T>(token.Value);
     }
 
     public dynamic GetItem(string key)
@@ -154,17 +171,17 @@ public class DataStore : IDataStore
         if (_reloadBeforeGetCollection)
         {
             // This might be a bad idea especially if the file is in use, as this can take a long time
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
 
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        var token = _jsonData[convertedKey];
+        var token = TryGetElement(_jsonData.RootElement, convertedKey);
 
         if (token == null)
             return null;
 
-        return SingleDynamicItemReadConverter(token);
+        return SingleDynamicItemReadConverter(token.Value);
     }
 
     public bool InsertItem<T>(string key, T item) => Insert(key, item).Result;
@@ -175,13 +192,15 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] != null)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data.HasValue)
+                return (false, data.Value);
 
-            _jsonData[convertedKey] = JToken.FromObject(item);
-            return (true, _jsonData);
+            var newElement = ConvertToJsonElement(item);
+            SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -195,13 +214,15 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] == null && upsert == false)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data == null && upsert == false)
+                return (false, _jsonData.RootElement);
 
-            _jsonData[convertedKey] = JToken.FromObject(item);
-            return (true, _jsonData);
+            var newElement = ConvertToJsonElement(item);
+            SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -215,24 +236,27 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] == null)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data == null)
+                return (false, _jsonData.RootElement);
 
-            var toUpdate = SingleDynamicItemReadConverter(_jsonData[convertedKey]);
+            var toUpdate = SingleDynamicItemReadConverter(data.Value);
 
             if (ObjectExtensions.IsReferenceType(item) && ObjectExtensions.IsReferenceType(toUpdate))
             {
                 ObjectExtensions.CopyProperties(item, toUpdate);
-                _jsonData[convertedKey] = JToken.FromObject(toUpdate);
+                var newElement = ConvertToJsonElement(toUpdate);
+                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
             }
             else
             {
-                _jsonData[convertedKey] = JToken.FromObject(item);
+                var newElement = ConvertToJsonElement(item);
+                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
             }
 
-            return (true, _jsonData);
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -246,10 +270,9 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            var result = _jsonData.Remove(convertedKey);
-            return (result, _jsonData);
+            return RemoveJsonDataElement(_jsonData.RootElement, convertedKey);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -257,8 +280,14 @@ public class DataStore : IDataStore
 
     public IDocumentCollection<T> GetCollection<T>(string name = null) where T : class
     {
-        // NOTE 27.6.2017: Should this be new Func<JToken, T>(e => e.ToObject<T>())?
-        var readConvert = new Func<JToken, T>(e => JsonConvert.DeserializeObject<T>(e.ToString()));
+        // Deserialize JsonElement to T
+        // Uses NewtonsoftDateTimeConverter for backward compatibility with Newtonsoft.Json DateTime formats
+        var readConvert = new Func<JsonElement, T>(e => e.Deserialize<T>(
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, true), new NewtonsoftDateTimeConverter() }
+            }));
         var insertConvert = new Func<T, T>(e => e);
         var createNewInstance = new Func<T>(() => Activator.CreateInstance<T>());
 
@@ -267,9 +296,13 @@ public class DataStore : IDataStore
 
     public IDocumentCollection<dynamic> GetCollection(string name)
     {
-        // As we don't want to return JObject when using dynamic, JObject will be converted to ExpandoObject
-        var readConvert = new Func<JToken, dynamic>(e => JsonConvert.DeserializeObject<ExpandoObject>(e.ToString(), _converter) as dynamic);
-        var insertConvert = new Func<dynamic, dynamic>(e => JsonConvert.DeserializeObject<ExpandoObject>(JsonConvert.SerializeObject(e), _converter));
+        // Deserialize JsonElement to ExpandoObject for dynamic handling
+        var readConvert = new Func<JsonElement, dynamic>(e => e.Deserialize<ExpandoObject>(_options));
+        var insertConvert = new Func<dynamic, dynamic>(e =>
+        {
+            var json = JsonSerializer.Serialize(e, _serializerOptions);
+            return JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+        });
         var createNewInstance = new Func<dynamic>(() => new ExpandoObject());
 
         return GetCollection(name, readConvert, insertConvert, createNewInstance);
@@ -277,57 +310,66 @@ public class DataStore : IDataStore
 
     public IDictionary<string, ValueType> GetKeys(ValueType? typeToGet = null)
     {
-        bool IsCollection(JToken c) => c.Children().FirstOrDefault() is JArray && c.Children().FirstOrDefault().Any() == false
-                                    || c.Children().FirstOrDefault()?.FirstOrDefault()?.Type == JTokenType.Object;
+        bool IsCollection(JsonElement property) =>
+   property.ValueKind == JsonValueKind.Array &&
+   (!property.EnumerateArray().Any() || property.EnumerateArray().First().ValueKind == JsonValueKind.Object);
 
-        bool IsItem(JToken c) => c.Children().FirstOrDefault().GetType() != typeof(JArray)
-                              || (c.Children().FirstOrDefault() is JArray
-                               && c.Children().FirstOrDefault().Any() // Empty array is considered as a collection
-                               && c.Children().FirstOrDefault()?.FirstOrDefault()?.Type != JTokenType.Object);
+        bool IsItem(JsonElement property) =>
+           property.ValueKind != JsonValueKind.Array ||
+           (property.EnumerateArray().Any() && property.EnumerateArray().First().ValueKind != JsonValueKind.Object);
 
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            switch (typeToGet)
+            var result = new Dictionary<string, ValueType>();
+
+            if (_jsonData.RootElement.ValueKind == JsonValueKind.Object)
             {
-                case null:
-                    return _jsonData.Children()
-                                    .ToDictionary(c => c.Path, c => IsCollection(c) ? ValueType.Collection : ValueType.Item);
+                foreach (var property in _jsonData.RootElement.EnumerateObject())
+                {
+                    bool isCollection = IsCollection(property.Value);
+                    bool isItem = IsItem(property.Value);
 
-                case ValueType.Collection:
-                    return _jsonData.Children()
-                                    .Where(IsCollection)
-                                    .ToDictionary(c => c.Path, c => ValueType.Collection);
-
-                case ValueType.Item:
-                    return _jsonData.Children()
-                                    .Where(IsItem)
-                                    .ToDictionary(c => c.Path, c => ValueType.Item);
-
-                default:
-                    throw new NotSupportedException();
+                    switch (typeToGet)
+                    {
+                        case null:
+                            result[property.Name] = isCollection ? ValueType.Collection : ValueType.Item;
+                            break;
+                        case ValueType.Collection when isCollection:
+                            result[property.Name] = ValueType.Collection;
+                            break;
+                        case ValueType.Item when isItem:
+                            result[property.Name] = ValueType.Item;
+                            break;
+                    }
+                }
             }
+
+            return result;
         }
     }
 
-    private IDocumentCollection<T> GetCollection<T>(string path, Func<JToken, T> readConvert, Func<T, T> insertConvert, Func<T> createNewInstance)
+    private IDocumentCollection<T> GetCollection<T>(string path, Func<JsonElement, T> readConvert, Func<T, T> insertConvert, Func<T> createNewInstance)
     {
         var pathWithConfiguredCase = _convertPathToCorrectCamelCase(path);
 
         var data = new Lazy<List<T>>(() =>
         {
-            lock (_jsonData)
+            lock (_jsonDataLock)
             {
                 if (_reloadBeforeGetCollection)
                 {
                     // This might be a bad idea especially if the file is in use, as this can take a long time
-                    _jsonData = GetJsonObjectFromFile();
+                    SetJsonData(GetJsonObjectFromFile());
                 }
 
-                return _jsonData[pathWithConfiguredCase]?
-                       .Children()
+                var data = TryGetElement(_jsonData.RootElement, pathWithConfiguredCase);
+
+                if (data.HasValue == false)
+                    return new List<T>();
+
+                return GetChildren(data.Value)
                        .Select(e => readConvert(e))
-                       .ToList()
-                    ?? new List<T>();
+                       .ToList();
             }
         });
 
@@ -340,7 +382,7 @@ public class DataStore : IDataStore
             createNewInstance);
     }
 
-    private async Task<bool> CommitItem(Func<(bool, JObject)> commitOperation, bool isOperationAsync)
+    private async Task<bool> CommitItem(Func<(bool, JsonElement)> commitOperation, bool isOperationAsync)
     {
         var commitAction = new CommitAction();
 
@@ -353,7 +395,7 @@ public class DataStore : IDataStore
         return await InnerCommit(isOperationAsync, commitAction);
     }
 
-    private async Task<bool> Commit<T>(string dataPath, Func<List<T>, bool> commitOperation, bool isOperationAsync, Func<JToken, T> readConvert)
+    private async Task<bool> Commit<T>(string dataPath, Func<List<T>, bool> commitOperation, bool isOperationAsync, Func<JsonElement, T> readConvert)
     {
         var commitAction = new CommitAction();
 
@@ -361,17 +403,19 @@ public class DataStore : IDataStore
         {
             var updatedJson = string.Empty;
 
-            var selectedData = currentJson[dataPath]?
-                               .Children()
+            var data = TryGetElement(currentJson, dataPath);
+
+            var selectedData = (data.HasValue) ? GetChildren(data.Value)
                                .Select(e => readConvert(e))
                                .ToList()
-                            ?? new List<T>();
+                            : new List<T>();
 
             var success = commitOperation(selectedData);
 
             if (success)
             {
-                currentJson[dataPath] = JArray.FromObject(selectedData);
+                var newElement = ConvertToJsonElement(selectedData);
+                currentJson = SetJsonDataElement(currentJson, dataPath, newElement).RootElement;
                 updatedJson = _toJsonFunc(currentJson);
             }
 
@@ -410,35 +454,231 @@ public class DataStore : IDataStore
         return actionSuccess;
     }
 
-    private dynamic SingleDynamicItemReadConverter(JToken e)
+    private dynamic SingleDynamicItemReadConverter(JsonElement e)
     {
-        switch (e)
+        switch (e.ValueKind)
         {
-            case var objToken when e.Type == JTokenType.Object:
-                //As we don't want to return JObject when using dynamic, JObject will be converted to ExpandoObject
-                // JToken.ToString() is not culture invariant, so need to use string.Format
-                var content = string.Format(CultureInfo.InvariantCulture, "{0}", objToken);
-                return JsonConvert.DeserializeObject<ExpandoObject>(content, _converter) as dynamic;
+            case JsonValueKind.Object:
+                // Convert JsonElement to ExpandoObject for a dynamic structure
+                var content = e.GetRawText(); // Get the JSON as a raw string
+                return JsonSerializer.Deserialize<ExpandoObject>(content, _options) as dynamic;
 
-            case var arrayToken when e.Type == JTokenType.Array:
-                return e.ToObject<List<object>>();
+            case JsonValueKind.Array:
+                // Convert JsonElement array to a List<object>
+                var list = new List<object>();
+                foreach (var item in e.EnumerateArray())
+                {
+                    list.Add(SingleDynamicItemReadConverter(item)); // Recursively handle each item
+                }
+                return list;
 
-            case JValue jv when e is JValue:
-                return jv.Value;
+            case JsonValueKind.String:
+                // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
+                // Performance Note: DateTime.TryParse() is expensive, so we use a heuristic
+                // to quickly filter out obvious non-date strings before attempting to parse.
+                var strValue = e.GetString();
+                if (!string.IsNullOrEmpty(strValue))
+                {
+                    // Quick heuristic: likely a date if it starts with a digit and contains date separators
+                    // This filters out most non-date strings very quickly
+                    // Common date formats: "2015-11-23T00:00:00", "6/15/2009", "2023-01-15"
+                    if (strValue.Length >= 8 && // Minimum reasonable date length (e.g., "1/1/2023")
+                        char.IsDigit(strValue[0]) &&
+                        (strValue.IndexOf('-') >= 0 || strValue.IndexOf('/') >= 0 || strValue.IndexOf('T') >= 0))
+                    {
+                        // Try InvariantCulture first (for ISO formats like "2015-11-23T00:00:00")
+                        if (DateTime.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateTime))
+                        {
+                            return dateTime;
+                        }
+                        // Fallback to current culture (for locale-specific formats like "6/15/2009")
+                        if (DateTime.TryParse(strValue, CultureInfo.CurrentCulture, DateTimeStyles.None, out dateTime))
+                        {
+                            return dateTime;
+                        }
+                    }
+                }
+                return strValue;
+
+            case JsonValueKind.Number:
+                return e.TryGetInt64(out long l) ? l : e.GetDouble();
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return e.GetBoolean();
+
+            case JsonValueKind.Null:
+                return null;
 
             default:
-                return e.ToObject<object>();
+                return e.GetRawText(); // Return as string for unknown types
         }
     }
 
+
+    private void SetJsonData(JsonDocument newData)
+    {
+        // Safely replaces _jsonData by disposing the old JsonDocument before assigning the new one.
+        // This prevents memory leaks by ensuring JsonDocument resources are properly released.
+        var oldData = _jsonData;
+        _jsonData = newData;
+        oldData?.Dispose();
+    }
     private string GetJsonTextFromFile() => FileAccess.ReadJsonFromFile(_filePath, _encryptJson, _decryptJson);
 
-    private JObject GetJsonObjectFromFile() => JObject.Parse(GetJsonTextFromFile());
+    private JsonDocument GetJsonObjectFromFile()
+    {
+        var jsonText = GetJsonTextFromFile();
+        return JsonDocument.Parse(jsonText);
+    }
+
+    private JsonElement? TryGetElement(JsonElement element, string key)
+    {
+        if (element.TryGetProperty(key, out JsonElement childElement))
+        {
+            return childElement;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private JsonDocument Parse(string json)
+    {
+        return JsonDocument.Parse(json);
+    }
+
+    private T ConvertJsonElementToObject<T>(JsonElement token)
+    {
+        // Special handling for DateTime to support Newtonsoft.Json format
+        if (typeof(T) == typeof(DateTime) && token.ValueKind == JsonValueKind.String)
+        {
+            var dateString = token.GetString();
+            var converter = new NewtonsoftDateTimeConverter();
+            var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes($"\"{dateString}\""));
+            reader.Read(); // Advance to the string token
+            return (T)(object)converter.Read(ref reader, typeof(DateTime), _options);
+        }
+
+        return JsonSerializer.Deserialize<T>(token.GetRawText(), _options);
+    }
+
+    private JsonElement ConvertToJsonElement(object item)
+    {
+        // Serialize the object to JSON with proper naming policy and parse it as a JsonDocument
+        var json = JsonSerializer.Serialize(item, _serializerOptions);
+        using var jsonDocument = JsonDocument.Parse(json);
+
+        // Clone the root element so it doesn't reference the disposed JsonDocument
+        // JsonElement is a struct that holds a reference to its parent document's buffer,
+        // so we must clone it to create a copy that's independent of the document's lifetime
+        return jsonDocument.RootElement.Clone();
+    }
+
+    private JsonDocument SetJsonDataElement(JsonElement original, string key, object item)
+    {
+        // Convert _jsonData to a Dictionary to make modifications
+        var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());
+
+        // Convert the item to JsonElement
+        var newElement = ConvertToJsonElement(item);
+
+        // Set or update the element in the dictionary
+        jsonDataDict[key] = newElement;
+
+        // Serialize back to JsonElement
+        var modifiedJson = JsonSerializer.Serialize(jsonDataDict);
+        return JsonDocument.Parse(modifiedJson);
+    }
+
+    public (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
+    {
+        // Deserialize _jsonData to a dictionary for modification
+        var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());
+
+        // Remove the specified key
+        var removed = jsonDataDict.Remove(key);
+
+        // Serialize the updated dictionary back to a JsonElement
+        var modifiedJson = JsonSerializer.Serialize(jsonDataDict);
+        using var jsonDocument = JsonDocument.Parse(modifiedJson);
+
+        // Clone the root element so it doesn't reference the disposed JsonDocument
+        return (removed, jsonDocument.RootElement.Clone());
+    }
+
+    private IEnumerable<JsonElement> GetChildren(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            // If element is an object, return its property values
+            // JsonElement is a struct - no disposal needed
+            return element.EnumerateObject().Select(p => p.Value);
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            // If element is an array, return the array items
+            // JsonElement is a struct - no disposal needed
+            return element.EnumerateArray();
+        }
+
+        // If it's neither an object nor an array, return an empty sequence
+        return Enumerable.Empty<JsonElement>();
+    }
+
+    public static string GetJsonPath(JsonElement root, JsonElement target)
+    {
+        return FindPath(root, target);
+    }
+
+    private static string FindPath(JsonElement element, JsonElement target, string currentPath = "")
+    {
+        if (element.Equals(target))
+        {
+            return currentPath;
+        }
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    var propertyPath = string.IsNullOrEmpty(currentPath)
+                        ? property.Name
+                        : $"{currentPath}.{property.Name}";
+
+                    var result = FindPath(property.Value, target, propertyPath);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                break;
+
+            case JsonValueKind.Array:
+                int index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    var arrayPath = $"{currentPath}[{index}]";
+
+                    var result = FindPath(item, target, arrayPath);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                    index++;
+                }
+                break;
+        }
+
+        return null; // Target not found in this branch
+    }
 
     internal class CommitAction
     {
         public Action<bool, Exception> Ready { get; set; }
 
-        public Func<JObject, (bool success, string json)> HandleAction { get; set; }
+        public Func<JsonElement, (bool success, string json)> HandleAction { get; set; }
     }
 }

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -21,7 +21,10 @@ public class DataStore : IDataStore
     private readonly JsonSerializerOptions _options = new JsonSerializerOptions
     {
         Converters = { new NewtonsoftDateTimeConverter(), new SystemExpandoObjectConverter() },
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        // Newtonsoft serialized NaN / Infinity / -Infinity as quoted literals by default.
+        // STJ would otherwise throw on these values.
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
     };
 
     private readonly JsonSerializerOptions _serializerOptions;
@@ -44,10 +47,12 @@ public class DataStore : IDataStore
         _serializerOptions = useLowerCamelCase ? new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = writeIntended
+            WriteIndented = writeIntended,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
         } : new JsonSerializerOptions
         {
-            WriteIndented = writeIntended
+            WriteIndented = writeIntended,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
         };
 
         _toJsonFunc = useLowerCamelCase
@@ -528,8 +533,25 @@ public class DataStore : IDataStore
 
     private JsonDocument GetJsonObjectFromFile()
     {
-        var jsonText = GetJsonTextFromFile();
-        return JsonDocument.Parse(jsonText);
+        // The writer is non-atomic (File.WriteAllText truncates then writes), so a concurrent
+        // reader can observe a partially-written file and JsonDocument.Parse will throw with
+        // "Expected end of string, but instead reached end of data". Retry briefly — the writer
+        // finishes in milliseconds. Cannot use a temp-file-then-rename strategy because users
+        // may have permission for the data file only.
+        const int maxAttempts = 50;
+        const int delayMs = 20;
+        for (var attempt = 0; ; attempt++)
+        {
+            var jsonText = GetJsonTextFromFile();
+            try
+            {
+                return JsonDocument.Parse(jsonText);
+            }
+            catch (JsonException) when (attempt < maxAttempts - 1)
+            {
+                System.Threading.Thread.Sleep(delayMs);
+            }
+        }
     }
 
     private JsonElement? TryGetElement(JsonElement element, string key)

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -253,12 +253,12 @@ public class DataStore : IDataStore
             {
                 ObjectExtensions.CopyProperties(item, toUpdate);
                 var newElement = ConvertToJsonElement(toUpdate);
-                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
+                SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
             }
             else
             {
                 var newElement = ConvertToJsonElement(item);
-                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
+                SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
             }
 
             return (true, _jsonData.RootElement);
@@ -614,7 +614,7 @@ public class DataStore : IDataStore
         return JsonDocument.Parse(modifiedJson);
     }
 
-    public (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
+    private (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
     {
         // Deserialize _jsonData to a dictionary for modification
         var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.Globalization;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -515,32 +514,12 @@ public class DataStore : IDataStore
                 return list;
 
             case JsonValueKind.String:
-                // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
-                // Performance Note: DateTime.TryParse() is expensive, so we use a heuristic
-                // to quickly filter out obvious non-date strings before attempting to parse.
-                var strValue = e.GetString();
-                if (!string.IsNullOrEmpty(strValue))
-                {
-                    // Quick heuristic: likely a date if it starts with a digit and contains date separators
-                    // This filters out most non-date strings very quickly
-                    // Common date formats: "2015-11-23T00:00:00", "6/15/2009", "2023-01-15"
-                    if (strValue.Length >= 8 && // Minimum reasonable date length (e.g., "1/1/2023")
-                        char.IsDigit(strValue[0]) &&
-                        (strValue.IndexOf('-') >= 0 || strValue.IndexOf('/') >= 0 || strValue.IndexOf('T') >= 0))
-                    {
-                        // Try InvariantCulture first (for ISO formats like "2015-11-23T00:00:00")
-                        if (DateTime.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateTime))
-                        {
-                            return dateTime;
-                        }
-                        // Fallback to current culture (for locale-specific formats like "6/15/2009")
-                        if (DateTime.TryParse(strValue, CultureInfo.CurrentCulture, DateTimeStyles.None, out dateTime))
-                        {
-                            return dateTime;
-                        }
-                    }
-                }
-                return strValue;
+                // Route through the same strict, invariant-culture date detection used by the
+                // collection/dynamic path (SystemExpandoObjectConverter). The previous heuristic
+                // here used a permissive DateTime.TryParse with a CurrentCulture fallback, so the
+                // single-item dynamic path (GetItem(key)) and the collection dynamic path could
+                // disagree on whether a string was a date, and results varied with machine locale.
+                return SystemExpandoObjectConverter.TryParseDateTime(e.GetString());
 
             case JsonValueKind.Number:
                 return e.TryGetInt64(out long l) ? l : e.GetDouble();

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -269,12 +269,12 @@ public class DataStore : IDataStore
             {
                 ObjectExtensions.CopyProperties(item, toUpdate);
                 var newElement = ConvertToJsonElement(toUpdate);
-                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
+                SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
             }
             else
             {
                 var newElement = ConvertToJsonElement(item);
-                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
+                SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
             }
 
             return (true, _jsonData.RootElement);
@@ -669,7 +669,7 @@ public class DataStore : IDataStore
         return JsonDocument.Parse(modifiedJson);
     }
 
-    public (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
+    private (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
     {
         // Deserialize _jsonData to a dictionary for modification
         var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -164,45 +164,56 @@ public class DataStore : IDataStore
 
     public T GetItem<T>(string key)
     {
-        if (_reloadBeforeGetCollection)
+        // Hold the lock for the whole read: the background commit thread disposes the previous
+        // JsonDocument the moment it swaps in a new one (SetJsonData), and the token below points
+        // into _jsonData's buffer. Reading it unsynchronized races into an ObjectDisposedException.
+        lock (_jsonDataLock)
         {
-            // This might be a bad idea especially if the file is in use, as this can take a long time
-            SetJsonData(GetJsonObjectFromFile());
-        }
-
-        var convertedKey = _convertPathToCorrectCamelCase(key);
-
-        var token = TryGetElement(_jsonData.RootElement, convertedKey);
-
-        if (token == null)
-        {
-            if (Nullable.GetUnderlyingType(typeof(T)) != null)
+            if (_reloadBeforeGetCollection)
             {
-                return default(T);
+                // This might be a bad idea especially if the file is in use, as this can take a long time
+                SetJsonData(GetJsonObjectFromFile());
             }
 
-            throw new KeyNotFoundException();
-        }
+            var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        return ConvertJsonElementToObject<T>(token.Value);
+            var token = TryGetElement(_jsonData.RootElement, convertedKey);
+
+            if (token == null)
+            {
+                if (Nullable.GetUnderlyingType(typeof(T)) != null)
+                {
+                    return default(T);
+                }
+
+                throw new KeyNotFoundException();
+            }
+
+            return ConvertJsonElementToObject<T>(token.Value);
+        }
     }
 
     public dynamic GetItem(string key)
     {
-        if (_reloadBeforeGetCollection)
+        // See GetItem<T> — the returned value is materialized from _jsonData's buffer, so the read
+        // must be synchronized against the background thread disposing the document.
+        lock (_jsonDataLock)
         {
-            // This might be a bad idea especially if the file is in use, as this can take a long time
-            SetJsonData(GetJsonObjectFromFile());
+            if (_reloadBeforeGetCollection)
+            {
+                // This might be a bad idea especially if the file is in use, as this can take a long time
+                SetJsonData(GetJsonObjectFromFile());
+            }
+
+            var convertedKey = _convertPathToCorrectCamelCase(key);
+
+            var token = TryGetElement(_jsonData.RootElement, convertedKey);
+
+            if (token == null)
+                return null;
+
+            return SingleDynamicItemReadConverter(token.Value);
         }
-
-        var convertedKey = _convertPathToCorrectCamelCase(key);
-
-        var token = TryGetElement(_jsonData.RootElement, convertedKey);
-
-        if (token == null)
-            return null;
-
-        return SingleDynamicItemReadConverter(token.Value);
     }
 
     public bool InsertItem<T>(string key, T item) => Insert(key, item).Result;
@@ -412,8 +423,14 @@ public class DataStore : IDataStore
 
         commitAction.HandleAction = (currentJson =>
         {
-            var (success, newJson) = commitOperation();
-            return success ? (true, _toJsonFunc(newJson)) : (false, string.Empty);
+            // commitOperation reads and reassigns _jsonData (disposing the old document) and newJson
+            // points into it; hold the lock across the serialization so a concurrent reader or
+            // Reload cannot dispose the document mid-operation.
+            lock (_jsonDataLock)
+            {
+                var (success, newJson) = commitOperation();
+                return success ? (true, _toJsonFunc(newJson)) : (false, string.Empty);
+            }
         });
 
         return await InnerCommit(isOperationAsync, commitAction);

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -21,7 +21,10 @@ public class DataStore : IDataStore
     private readonly JsonSerializerOptions _options = new JsonSerializerOptions
     {
         Converters = { new NewtonsoftDateTimeConverter(), new SystemExpandoObjectConverter() },
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        // Newtonsoft serialized NaN / Infinity / -Infinity as quoted literals by default.
+        // STJ would otherwise throw on these values.
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
     };
 
     private readonly JsonSerializerOptions _serializerOptions;
@@ -44,10 +47,12 @@ public class DataStore : IDataStore
         _serializerOptions = useLowerCamelCase ? new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = writeIntended
+            WriteIndented = writeIntended,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
         } : new JsonSerializerOptions
         {
-            WriteIndented = writeIntended
+            WriteIndented = writeIntended,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
         };
 
         _toJsonFunc = useLowerCamelCase
@@ -556,8 +561,25 @@ public class DataStore : IDataStore
 
     private JsonDocument GetJsonObjectFromFile()
     {
-        var jsonText = GetJsonTextFromFile();
-        return JsonDocument.Parse(jsonText);
+        // The writer is non-atomic (File.WriteAllText truncates then writes), so a concurrent
+        // reader can observe a partially-written file and JsonDocument.Parse will throw with
+        // "Expected end of string, but instead reached end of data". Retry briefly — the writer
+        // finishes in milliseconds. Cannot use a temp-file-then-rename strategy because users
+        // may have permission for the data file only.
+        const int maxAttempts = 50;
+        const int delayMs = 20;
+        for (var attempt = 0; ; attempt++)
+        {
+            var jsonText = GetJsonTextFromFile();
+            try
+            {
+                return JsonDocument.Parse(jsonText);
+            }
+            catch (JsonException) when (attempt < maxAttempts - 1)
+            {
+                System.Threading.Thread.Sleep(delayMs);
+            }
+        }
     }
 
     private JsonElement? TryGetElement(JsonElement element, string key)

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -3,12 +3,9 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace JsonFlatFileDataStore;
 
@@ -17,19 +14,23 @@ public class DataStore : IDataStore
     private readonly string _filePath;
     private readonly string _keyProperty;
     private readonly bool _reloadBeforeGetCollection;
-    private readonly Func<JObject, string> _toJsonFunc;
+    private readonly Func<JsonElement, string> _toJsonFunc;
     private readonly Func<string, string> _convertPathToCorrectCamelCase;
     private readonly BlockingCollection<CommitAction> _updates = new BlockingCollection<CommitAction>();
     private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-    private readonly ExpandoObjectConverter _converter = new ExpandoObjectConverter();
+    private readonly JsonSerializerOptions _options = new JsonSerializerOptions
+    {
+        Converters = { new NewtonsoftDateTimeConverter(), new SystemExpandoObjectConverter() },
+        PropertyNameCaseInsensitive = true
+    };
 
-    private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings()
-    { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+    private readonly JsonSerializerOptions _serializerOptions;
 
     private readonly Func<string, string> _encryptJson;
     private readonly Func<string, string> _decryptJson;
 
-    private JObject _jsonData;
+    private JsonDocument _jsonData;
+    private readonly object _jsonDataLock = new object();
     private bool _executingJsonUpdate;
 
     public DataStore(string path, bool useLowerCamelCase = true, string keyProperty = null, bool reloadBeforeGetCollection = false,
@@ -38,17 +39,28 @@ public class DataStore : IDataStore
         _filePath = path;
 
         var useEncryption = !string.IsNullOrWhiteSpace(encryptionKey);
-        var usedFormatting = minifyJson || useEncryption ? Formatting.None : Formatting.Indented;
+        var writeIntended = !minifyJson && !useEncryption;  // Set to `true` if not minifying or encrypting
+
+        _serializerOptions = useLowerCamelCase ? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = writeIntended
+        } : new JsonSerializerOptions
+        {
+            WriteIndented = writeIntended
+        };
 
         _toJsonFunc = useLowerCamelCase
-            ? new Func<JObject, string>(data =>
+            ? new Func<JsonElement, string>(data =>
             {
-                // Serializing JObject ignores SerializerSettings, so we have to first deserialize to ExpandoObject and then serialize
-                // http://json.codeplex.com/workitem/23853
-                var jObject = JsonConvert.DeserializeObject<ExpandoObject>(data.ToString());
-                return JsonConvert.SerializeObject(jObject, usedFormatting, _serializerSettings);
+                // Deserialize to ExpandoObject to allow flexible serialization settings
+                var expandoObject = JsonSerializer.Deserialize<ExpandoObject>(data.GetRawText(), _options);
+
+                // Serialize back to JSON with camel casing and indentation options applied
+                // Case-insensitive property matching is handled in ObjectExtensions.CopyProperties
+                return JsonSerializer.Serialize(expandoObject, _serializerOptions);
             })
-            : (s => s.ToString(usedFormatting));
+            : (s => JsonSerializer.Serialize(s, _serializerOptions));
 
         _convertPathToCorrectCamelCase = useLowerCamelCase
             ? new Func<string, string>(s => string.Concat(s.Select((x, i) => i == 0 ? char.ToLower(x).ToString() : x.ToString())))
@@ -70,7 +82,7 @@ public class DataStore : IDataStore
             _decryptJson = (json => json);
         }
 
-        _jsonData = GetJsonObjectFromFile();
+        SetJsonData(GetJsonObjectFromFile());
 
         // Run updates on a dedicated background thread and use BlockingCollection to prevent multiple updates to run simultaneously.
         // The handler blocks on Take() for the whole lifetime of the store, so it must not sit on a thread pool thread: a process
@@ -84,9 +96,9 @@ public class DataStore : IDataStore
                     executionState => _executingJsonUpdate = executionState,
                     jsonText =>
                     {
-                        lock (_jsonData)
+                        lock (_jsonDataLock)
                         {
-                            _jsonData = JObject.Parse(jsonText);
+                            SetJsonData(Parse(jsonText));
                         }
 
                         return FileAccess.WriteJsonToFile(_filePath, _encryptJson, jsonText);
@@ -118,15 +130,20 @@ public class DataStore : IDataStore
         {
             _cts.Cancel();
         }
+
+        // Dispose the JsonDocument to free unmanaged resources
+        _jsonData?.Dispose();
     }
+
+
 
     public bool IsUpdating => _updates.Count > 0 || _executingJsonUpdate;
 
     public void UpdateAll(string jsonData)
     {
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            _jsonData = JObject.Parse(jsonData);
+            SetJsonData(Parse(jsonData));
         }
 
         FileAccess.WriteJsonToFile(_filePath, _encryptJson, jsonData);
@@ -134,9 +151,9 @@ public class DataStore : IDataStore
 
     public void Reload()
     {
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
     }
 
@@ -145,12 +162,12 @@ public class DataStore : IDataStore
         if (_reloadBeforeGetCollection)
         {
             // This might be a bad idea especially if the file is in use, as this can take a long time
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
 
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        var token = _jsonData[convertedKey];
+        var token = TryGetElement(_jsonData.RootElement, convertedKey);
 
         if (token == null)
         {
@@ -162,7 +179,7 @@ public class DataStore : IDataStore
             throw new KeyNotFoundException();
         }
 
-        return token.ToObject<T>();
+        return ConvertJsonElementToObject<T>(token.Value);
     }
 
     public dynamic GetItem(string key)
@@ -170,17 +187,17 @@ public class DataStore : IDataStore
         if (_reloadBeforeGetCollection)
         {
             // This might be a bad idea especially if the file is in use, as this can take a long time
-            _jsonData = GetJsonObjectFromFile();
+            SetJsonData(GetJsonObjectFromFile());
         }
 
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        var token = _jsonData[convertedKey];
+        var token = TryGetElement(_jsonData.RootElement, convertedKey);
 
         if (token == null)
             return null;
 
-        return SingleDynamicItemReadConverter(token);
+        return SingleDynamicItemReadConverter(token.Value);
     }
 
     public bool InsertItem<T>(string key, T item) => Insert(key, item).Result;
@@ -191,13 +208,15 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] != null)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data.HasValue)
+                return (false, data.Value);
 
-            _jsonData[convertedKey] = JToken.FromObject(item);
-            return (true, _jsonData);
+            var newElement = ConvertToJsonElement(item);
+            SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -211,13 +230,15 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] == null && upsert == false)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data == null && upsert == false)
+                return (false, _jsonData.RootElement);
 
-            _jsonData[convertedKey] = JToken.FromObject(item);
-            return (true, _jsonData);
+            var newElement = ConvertToJsonElement(item);
+            SetJsonData(SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement));
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -231,24 +252,27 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            if (_jsonData[convertedKey] == null)
-                return (false, _jsonData);
+            var data = TryGetElement(_jsonData.RootElement, convertedKey);
+            if (data == null)
+                return (false, _jsonData.RootElement);
 
-            var toUpdate = SingleDynamicItemReadConverter(_jsonData[convertedKey]);
+            var toUpdate = SingleDynamicItemReadConverter(data.Value);
 
             if (ObjectExtensions.IsReferenceType(item) && ObjectExtensions.IsReferenceType(toUpdate))
             {
                 ObjectExtensions.CopyProperties(item, toUpdate);
-                _jsonData[convertedKey] = JToken.FromObject(toUpdate);
+                var newElement = ConvertToJsonElement(toUpdate);
+                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
             }
             else
             {
-                _jsonData[convertedKey] = JToken.FromObject(item);
+                var newElement = ConvertToJsonElement(item);
+                _jsonData = SetJsonDataElement(_jsonData.RootElement, convertedKey, newElement);
             }
 
-            return (true, _jsonData);
+            return (true, _jsonData.RootElement);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -262,10 +286,9 @@ public class DataStore : IDataStore
     {
         var convertedKey = _convertPathToCorrectCamelCase(key);
 
-        (bool, JObject) UpdateAction()
+        (bool, JsonElement) UpdateAction()
         {
-            var result = _jsonData.Remove(convertedKey);
-            return (result, _jsonData);
+            return RemoveJsonDataElement(_jsonData.RootElement, convertedKey);
         }
 
         return CommitItem(UpdateAction, isAsync);
@@ -273,8 +296,14 @@ public class DataStore : IDataStore
 
     public IDocumentCollection<T> GetCollection<T>(string name = null) where T : class
     {
-        // NOTE 27.6.2017: Should this be new Func<JToken, T>(e => e.ToObject<T>())?
-        var readConvert = new Func<JToken, T>(e => JsonConvert.DeserializeObject<T>(e.ToString()));
+        // Deserialize JsonElement to T
+        // Uses NewtonsoftDateTimeConverter for backward compatibility with Newtonsoft.Json DateTime formats
+        var readConvert = new Func<JsonElement, T>(e => e.Deserialize<T>(
+            new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, true), new NewtonsoftDateTimeConverter() }
+            }));
         var insertConvert = new Func<T, T>(e => e);
         var createNewInstance = new Func<T>(() => Activator.CreateInstance<T>());
 
@@ -283,9 +312,13 @@ public class DataStore : IDataStore
 
     public IDocumentCollection<dynamic> GetCollection(string name)
     {
-        // As we don't want to return JObject when using dynamic, JObject will be converted to ExpandoObject
-        var readConvert = new Func<JToken, dynamic>(e => JsonConvert.DeserializeObject<ExpandoObject>(e.ToString(), _converter) as dynamic);
-        var insertConvert = new Func<dynamic, dynamic>(e => JsonConvert.DeserializeObject<ExpandoObject>(JsonConvert.SerializeObject(e), _converter));
+        // Deserialize JsonElement to ExpandoObject for dynamic handling
+        var readConvert = new Func<JsonElement, dynamic>(e => e.Deserialize<ExpandoObject>(_options));
+        var insertConvert = new Func<dynamic, dynamic>(e =>
+        {
+            var json = JsonSerializer.Serialize(e, _serializerOptions);
+            return JsonSerializer.Deserialize<ExpandoObject>(json, _options);
+        });
         var createNewInstance = new Func<dynamic>(() => new ExpandoObject());
 
         return GetCollection(name, readConvert, insertConvert, createNewInstance);
@@ -293,60 +326,69 @@ public class DataStore : IDataStore
 
     public IDictionary<string, ValueType> GetKeys(ValueType? typeToGet = null)
     {
-        bool IsCollection(JToken c) => c.Children().FirstOrDefault() is JArray && c.Children().FirstOrDefault().Any() == false
-                                    || c.Children().FirstOrDefault()?.FirstOrDefault()?.Type == JTokenType.Object;
+        bool IsCollection(JsonElement property) =>
+   property.ValueKind == JsonValueKind.Array &&
+   (!property.EnumerateArray().Any() || property.EnumerateArray().First().ValueKind == JsonValueKind.Object);
 
-        bool IsItem(JToken c) => c.Children().FirstOrDefault().GetType() != typeof(JArray)
-                              || (c.Children().FirstOrDefault() is JArray
-                               && c.Children().FirstOrDefault().Any() // Empty array is considered as a collection
-                               && c.Children().FirstOrDefault()?.FirstOrDefault()?.Type != JTokenType.Object);
+        bool IsItem(JsonElement property) =>
+           property.ValueKind != JsonValueKind.Array ||
+           (property.EnumerateArray().Any() && property.EnumerateArray().First().ValueKind != JsonValueKind.Object);
 
-        lock (_jsonData)
+        lock (_jsonDataLock)
         {
-            switch (typeToGet)
+            var result = new Dictionary<string, ValueType>();
+
+            if (_jsonData.RootElement.ValueKind == JsonValueKind.Object)
             {
-                case null:
-                    return _jsonData.Children()
-                                    .ToDictionary(c => c.Path, c => IsCollection(c) ? ValueType.Collection : ValueType.Item);
+                foreach (var property in _jsonData.RootElement.EnumerateObject())
+                {
+                    bool isCollection = IsCollection(property.Value);
+                    bool isItem = IsItem(property.Value);
 
-                case ValueType.Collection:
-                    return _jsonData.Children()
-                                    .Where(IsCollection)
-                                    .ToDictionary(c => c.Path, c => ValueType.Collection);
-
-                case ValueType.Item:
-                    return _jsonData.Children()
-                                    .Where(IsItem)
-                                    .ToDictionary(c => c.Path, c => ValueType.Item);
-
-                default:
-                    throw new NotSupportedException();
+                    switch (typeToGet)
+                    {
+                        case null:
+                            result[property.Name] = isCollection ? ValueType.Collection : ValueType.Item;
+                            break;
+                        case ValueType.Collection when isCollection:
+                            result[property.Name] = ValueType.Collection;
+                            break;
+                        case ValueType.Item when isItem:
+                            result[property.Name] = ValueType.Item;
+                            break;
+                    }
+                }
             }
+
+            return result;
         }
     }
 
-    private IDocumentCollection<T> GetCollection<T>(string path, Func<JToken, T> readConvert, Func<T, T> insertConvert, Func<T> createNewInstance)
+    private IDocumentCollection<T> GetCollection<T>(string path, Func<JsonElement, T> readConvert, Func<T, T> insertConvert, Func<T> createNewInstance)
     {
         var pathWithConfiguredCase = _convertPathToCorrectCamelCase(path);
 
         var data = new Lazy<List<T>>(() =>
         {
-            lock (_jsonData)
+            lock (_jsonDataLock)
             {
                 if (_reloadBeforeGetCollection)
                 {
                     // This might be a bad idea especially if the file is in use, as this can take a long time
-                    _jsonData = GetJsonObjectFromFile();
+                    SetJsonData(GetJsonObjectFromFile());
                 }
 
                 // Match case-insensitively: in camelCase mode the lookup path is camelCased
                 // (e.g. "user") but a file authored elsewhere may store the key as "User".
                 // A case-sensitive miss would incorrectly read the collection as empty.
-                return _jsonData.Property(pathWithConfiguredCase, StringComparison.OrdinalIgnoreCase)?.Value
-                       .Children()
+                var data = TryGetElementIgnoreCase(_jsonData.RootElement, pathWithConfiguredCase);
+
+                if (data.HasValue == false)
+                    return new List<T>();
+
+                return GetChildren(data.Value)
                        .Select(e => readConvert(e))
-                       .ToList()
-                    ?? new List<T>();
+                       .ToList();
             }
         });
 
@@ -359,7 +401,7 @@ public class DataStore : IDataStore
             createNewInstance);
     }
 
-    private async Task<bool> CommitItem(Func<(bool, JObject)> commitOperation, bool isOperationAsync)
+    private async Task<bool> CommitItem(Func<(bool, JsonElement)> commitOperation, bool isOperationAsync)
     {
         var commitAction = new CommitAction();
 
@@ -372,7 +414,7 @@ public class DataStore : IDataStore
         return await InnerCommit(isOperationAsync, commitAction);
     }
 
-    private async Task<bool> Commit<T>(string dataPath, Func<List<T>, bool> commitOperation, bool isOperationAsync, Func<JToken, T> readConvert)
+    private async Task<bool> Commit<T>(string dataPath, Func<List<T>, bool> commitOperation, bool isOperationAsync, Func<JsonElement, T> readConvert)
     {
         var commitAction = new CommitAction();
 
@@ -382,29 +424,26 @@ public class DataStore : IDataStore
 
             // Match case-insensitively so a Pascal-cased key in an externally authored file
             // ("User") is found by the camelCased lookup path ("user").
-            var existingProperty = currentJson.Property(dataPath, StringComparison.OrdinalIgnoreCase);
+            var existingKey = FindPropertyNameIgnoreCase(currentJson, dataPath);
 
-            var selectedData = existingProperty?.Value
-                               .Children()
+            var data = existingKey != null ? TryGetElement(currentJson, existingKey) : null;
+
+            var selectedData = (data.HasValue) ? GetChildren(data.Value)
                                .Select(e => readConvert(e))
                                .ToList()
-                            ?? new List<T>();
+                            : new List<T>();
 
             var success = commitOperation(selectedData);
 
             if (success)
             {
-                var newArray = JArray.FromObject(selectedData);
+                var newElement = ConvertToJsonElement(selectedData);
 
-                // Update the existing property in place (preserving its key) rather than adding a
-                // second property that differs only by case; _toJsonFunc normalizes the key to
-                // camelCase on write. Setting currentJson[dataPath] directly would leave the
-                // original "User" key alongside a new "user" key, corrupting the document.
-                if (existingProperty != null)
-                    existingProperty.Value = newArray;
-                else
-                    currentJson[dataPath] = newArray;
-
+                // Write back under the key that already exists (preserving its case) rather than
+                // adding a second property that differs only by case; _toJsonFunc normalizes the
+                // key to camelCase on write. Using dataPath directly would leave the original
+                // "User" key alongside a new "user" key, corrupting the document.
+                currentJson = SetJsonDataElement(currentJson, existingKey ?? dataPath, newElement).RootElement;
                 updatedJson = _toJsonFunc(currentJson);
             }
 
@@ -443,55 +482,258 @@ public class DataStore : IDataStore
         return actionSuccess;
     }
 
-    private dynamic SingleDynamicItemReadConverter(JToken e)
+    private dynamic SingleDynamicItemReadConverter(JsonElement e)
     {
-        switch (e)
+        switch (e.ValueKind)
         {
-            case var objToken when e.Type == JTokenType.Object:
-                //As we don't want to return JObject when using dynamic, JObject will be converted to ExpandoObject
-                // JToken.ToString() is not culture invariant, so need to use string.Format
-                var content = string.Format(CultureInfo.InvariantCulture, "{0}", objToken);
-                return JsonConvert.DeserializeObject<ExpandoObject>(content, _converter) as dynamic;
+            case JsonValueKind.Object:
+                // Convert JsonElement to ExpandoObject for a dynamic structure
+                var content = e.GetRawText(); // Get the JSON as a raw string
+                return JsonSerializer.Deserialize<ExpandoObject>(content, _options) as dynamic;
 
-            case var arrayToken when e.Type == JTokenType.Array:
-                return e.ToObject<List<object>>();
+            case JsonValueKind.Array:
+                // Convert JsonElement array to a List<object>
+                var list = new List<object>();
+                foreach (var item in e.EnumerateArray())
+                {
+                    list.Add(SingleDynamicItemReadConverter(item)); // Recursively handle each item
+                }
+                return list;
 
-            case JValue jv when e is JValue:
-                return jv.Value;
+            case JsonValueKind.String:
+                // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
+                // Performance Note: DateTime.TryParse() is expensive, so we use a heuristic
+                // to quickly filter out obvious non-date strings before attempting to parse.
+                var strValue = e.GetString();
+                if (!string.IsNullOrEmpty(strValue))
+                {
+                    // Quick heuristic: likely a date if it starts with a digit and contains date separators
+                    // This filters out most non-date strings very quickly
+                    // Common date formats: "2015-11-23T00:00:00", "6/15/2009", "2023-01-15"
+                    if (strValue.Length >= 8 && // Minimum reasonable date length (e.g., "1/1/2023")
+                        char.IsDigit(strValue[0]) &&
+                        (strValue.IndexOf('-') >= 0 || strValue.IndexOf('/') >= 0 || strValue.IndexOf('T') >= 0))
+                    {
+                        // Try InvariantCulture first (for ISO formats like "2015-11-23T00:00:00")
+                        if (DateTime.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateTime))
+                        {
+                            return dateTime;
+                        }
+                        // Fallback to current culture (for locale-specific formats like "6/15/2009")
+                        if (DateTime.TryParse(strValue, CultureInfo.CurrentCulture, DateTimeStyles.None, out dateTime))
+                        {
+                            return dateTime;
+                        }
+                    }
+                }
+                return strValue;
+
+            case JsonValueKind.Number:
+                return e.TryGetInt64(out long l) ? l : e.GetDouble();
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return e.GetBoolean();
+
+            case JsonValueKind.Null:
+                return null;
 
             default:
-                return e.ToObject<object>();
+                return e.GetRawText(); // Return as string for unknown types
         }
     }
 
+
+    private void SetJsonData(JsonDocument newData)
+    {
+        // Safely replaces _jsonData by disposing the old JsonDocument before assigning the new one.
+        // This prevents memory leaks by ensuring JsonDocument resources are properly released.
+        var oldData = _jsonData;
+        _jsonData = newData;
+        oldData?.Dispose();
+    }
     private string GetJsonTextFromFile() => FileAccess.ReadJsonFromFile(_filePath, _encryptJson, _decryptJson);
 
-    private JObject GetJsonObjectFromFile()
+    private JsonDocument GetJsonObjectFromFile()
     {
-        // The writer is non-atomic (File.WriteAllText truncates then writes), so a concurrent
-        // reader can observe a partially-written file and JObject.Parse will throw. Retry briefly —
-        // the writer finishes in milliseconds. Cannot use a temp-file-then-rename strategy because
-        // users may have permission for the data file only.
-        const int maxAttempts = 50;
-        const int delayMs = 20;
-        for (var attempt = 0; ; attempt++)
+        var jsonText = GetJsonTextFromFile();
+        return JsonDocument.Parse(jsonText);
+    }
+
+    private JsonElement? TryGetElement(JsonElement element, string key)
+    {
+        if (element.TryGetProperty(key, out JsonElement childElement))
         {
-            var jsonText = GetJsonTextFromFile();
-            try
-            {
-                return JObject.Parse(jsonText);
-            }
-            catch (JsonReaderException) when (attempt < maxAttempts - 1)
-            {
-                Thread.Sleep(delayMs);
-            }
+            return childElement;
         }
+        else
+        {
+            return null;
+        }
+    }
+
+    private JsonElement? TryGetElementIgnoreCase(JsonElement element, string key)
+    {
+        var actualKey = FindPropertyNameIgnoreCase(element, key);
+        return actualKey != null ? TryGetElement(element, actualKey) : null;
+    }
+
+    /// <summary>
+    /// Returns the property name as it is stored in the document, matching case-insensitively,
+    /// or null when the element has no such property. An exact match always wins.
+    /// </summary>
+    private static string FindPropertyNameIgnoreCase(JsonElement element, string key)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (element.TryGetProperty(key, out _))
+            return key;
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, key, StringComparison.OrdinalIgnoreCase))
+                return property.Name;
+        }
+
+        return null;
+    }
+
+    private JsonDocument Parse(string json)
+    {
+        return JsonDocument.Parse(json);
+    }
+
+    private T ConvertJsonElementToObject<T>(JsonElement token)
+    {
+        // Special handling for DateTime to support Newtonsoft.Json format
+        if (typeof(T) == typeof(DateTime) && token.ValueKind == JsonValueKind.String)
+        {
+            var dateString = token.GetString();
+            var converter = new NewtonsoftDateTimeConverter();
+            var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes($"\"{dateString}\""));
+            reader.Read(); // Advance to the string token
+            return (T)(object)converter.Read(ref reader, typeof(DateTime), _options);
+        }
+
+        return JsonSerializer.Deserialize<T>(token.GetRawText(), _options);
+    }
+
+    private JsonElement ConvertToJsonElement(object item)
+    {
+        // Serialize the object to JSON with proper naming policy and parse it as a JsonDocument
+        var json = JsonSerializer.Serialize(item, _serializerOptions);
+        using var jsonDocument = JsonDocument.Parse(json);
+
+        // Clone the root element so it doesn't reference the disposed JsonDocument
+        // JsonElement is a struct that holds a reference to its parent document's buffer,
+        // so we must clone it to create a copy that's independent of the document's lifetime
+        return jsonDocument.RootElement.Clone();
+    }
+
+    private JsonDocument SetJsonDataElement(JsonElement original, string key, object item)
+    {
+        // Convert _jsonData to a Dictionary to make modifications
+        var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());
+
+        // Convert the item to JsonElement
+        var newElement = ConvertToJsonElement(item);
+
+        // Set or update the element in the dictionary
+        jsonDataDict[key] = newElement;
+
+        // Serialize back to JsonElement
+        var modifiedJson = JsonSerializer.Serialize(jsonDataDict);
+        return JsonDocument.Parse(modifiedJson);
+    }
+
+    public (bool, JsonElement) RemoveJsonDataElement(JsonElement original, string key)
+    {
+        // Deserialize _jsonData to a dictionary for modification
+        var jsonDataDict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(original.GetRawText());
+
+        // Remove the specified key
+        var removed = jsonDataDict.Remove(key);
+
+        // Serialize the updated dictionary back to a JsonElement
+        var modifiedJson = JsonSerializer.Serialize(jsonDataDict);
+        using var jsonDocument = JsonDocument.Parse(modifiedJson);
+
+        // Clone the root element so it doesn't reference the disposed JsonDocument
+        return (removed, jsonDocument.RootElement.Clone());
+    }
+
+    private IEnumerable<JsonElement> GetChildren(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            // If element is an object, return its property values
+            // JsonElement is a struct - no disposal needed
+            return element.EnumerateObject().Select(p => p.Value);
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            // If element is an array, return the array items
+            // JsonElement is a struct - no disposal needed
+            return element.EnumerateArray();
+        }
+
+        // If it's neither an object nor an array, return an empty sequence
+        return Enumerable.Empty<JsonElement>();
+    }
+
+    public static string GetJsonPath(JsonElement root, JsonElement target)
+    {
+        return FindPath(root, target);
+    }
+
+    private static string FindPath(JsonElement element, JsonElement target, string currentPath = "")
+    {
+        if (element.Equals(target))
+        {
+            return currentPath;
+        }
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    var propertyPath = string.IsNullOrEmpty(currentPath)
+                        ? property.Name
+                        : $"{currentPath}.{property.Name}";
+
+                    var result = FindPath(property.Value, target, propertyPath);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                break;
+
+            case JsonValueKind.Array:
+                int index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    var arrayPath = $"{currentPath}[{index}]";
+
+                    var result = FindPath(item, target, arrayPath);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                    index++;
+                }
+                break;
+        }
+
+        return null; // Target not found in this branch
     }
 
     internal class CommitAction
     {
         public Action<bool, Exception> Ready { get; set; }
 
-        public Func<JObject, (bool success, string json)> HandleAction { get; set; }
+        public Func<JsonElement, (bool success, string json)> HandleAction { get; set; }
     }
 }

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -56,15 +56,7 @@ public class DataStore : IDataStore
         };
 
         _toJsonFunc = useLowerCamelCase
-            ? new Func<JsonElement, string>(data =>
-            {
-                // Deserialize to ExpandoObject to allow flexible serialization settings
-                var expandoObject = JsonSerializer.Deserialize<ExpandoObject>(data.GetRawText(), _options);
-
-                // Serialize back to JSON with camel casing and indentation options applied
-                // Case-insensitive property matching is handled in ObjectExtensions.CopyProperties
-                return JsonSerializer.Serialize(expandoObject, _serializerOptions);
-            })
+            ? new Func<JsonElement, string>(data => SerializeCamelCase(data, writeIntended))
             : (s => JsonSerializer.Serialize(s, _serializerOptions));
 
         _convertPathToCorrectCamelCase = useLowerCamelCase
@@ -656,6 +648,51 @@ public class DataStore : IDataStore
         }
 
         return JsonSerializer.Deserialize<T>(token.GetRawText(), _options);
+    }
+
+    // Rewrites the document to lower camelCase property names while preserving every value byte-for-byte.
+    // The previous implementation round-tripped through ExpandoObject, which ran the date-detection
+    // heuristic (SystemExpandoObjectConverter.TryParseDateTime) over every string. That silently
+    // rewrote any date-looking string — e.g. a "2015-11-23" version field — into "2015-11-23T00:00:00"
+    // on the next unrelated write. Walking the JsonElement directly touches only property names.
+    private static string SerializeCamelCase(JsonElement data, bool writeIndented)
+    {
+        using var stream = new System.IO.MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = writeIndented }))
+        {
+            WriteCamelCase(data, writer);
+        }
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void WriteCamelCase(JsonElement element, Utf8JsonWriter writer)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (var property in element.EnumerateObject())
+                {
+                    writer.WritePropertyName(JsonNamingPolicy.CamelCase.ConvertName(property.Name));
+                    WriteCamelCase(property.Value, writer);
+                }
+                writer.WriteEndObject();
+                break;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                {
+                    WriteCamelCase(item, writer);
+                }
+                writer.WriteEndArray();
+                break;
+
+            default:
+                element.WriteTo(writer);
+                break;
+        }
     }
 
     private JsonElement ConvertToJsonElement(object item)

--- a/JsonFlatFileDataStore/DocumentCollection.cs
+++ b/JsonFlatFileDataStore/DocumentCollection.cs
@@ -2,8 +2,6 @@
 using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace JsonFlatFileDataStore;
 
@@ -410,12 +408,21 @@ public class DocumentCollection<T> : IDocumentCollection<T>
         if (keyValue is Int64)
             return (int)keyValue + 1;
 
+        if (keyValue is Int32)
+            return (int)keyValue + 1;
+
         return ParseNextIntegerToKeyValue(keyValue.ToString());
     }
 
     private dynamic GetFieldValue(T item, string fieldName)
     {
-        var expando = JsonConvert.DeserializeObject<ExpandoObject>(JsonConvert.SerializeObject(item), new ExpandoObjectConverter());
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new SystemExpandoObjectConverter() },
+            PropertyNameCaseInsensitive = true // Optional: make property name matching case-insensitive
+        };
+
+        var expando = JsonSerializer.Deserialize<ExpandoObject>(JsonSerializer.Serialize(item), options);
         // Problem here is if we have typed data with upper camel case properties but lower camel case in JSON, so need to use OrdinalIgnoreCase string comparer
         var expandoAsIgnoreCase = new Dictionary<string, dynamic>(expando, StringComparer.OrdinalIgnoreCase);
 

--- a/JsonFlatFileDataStore/DocumentCollection.cs
+++ b/JsonFlatFileDataStore/DocumentCollection.cs
@@ -414,15 +414,23 @@ public class DocumentCollection<T> : IDocumentCollection<T>
         return ParseNextIntegerToKeyValue(keyValue.ToString());
     }
 
+    // Reused between calls, as a new JsonSerializerOptions instance would throw away
+    // System.Text.Json's cached type metadata on every lookup
+    private static readonly JsonSerializerOptions _fieldValueOptions = new JsonSerializerOptions
+    {
+        Converters = { new SystemExpandoObjectConverter() },
+        PropertyNameCaseInsensitive = true // Optional: make property name matching case-insensitive
+    };
+
     private dynamic GetFieldValue(T item, string fieldName)
     {
-        var options = new JsonSerializerOptions
-        {
-            Converters = { new SystemExpandoObjectConverter() },
-            PropertyNameCaseInsensitive = true // Optional: make property name matching case-insensitive
-        };
+        // Dynamic items are already dictionaries, so the field can be read without serializing
+        // the whole item. Typed items are serialized, as the id value has to be in the same
+        // format as it is in JSON, e.g. a Guid is handled as a string.
+        var expando = item is IDictionary<string, object> itemDictionary
+            ? itemDictionary
+            : JsonSerializer.SerializeToElement(item).Deserialize<ExpandoObject>(_fieldValueOptions);
 
-        var expando = JsonSerializer.Deserialize<ExpandoObject>(JsonSerializer.Serialize(item), options);
         // Problem here is if we have typed data with upper camel case properties but lower camel case in JSON, so need to use OrdinalIgnoreCase string comparer
         var expandoAsIgnoreCase = new Dictionary<string, dynamic>(expando, StringComparer.OrdinalIgnoreCase);
 

--- a/JsonFlatFileDataStore/ExpandoObjectConverter.cs
+++ b/JsonFlatFileDataStore/ExpandoObjectConverter.cs
@@ -1,0 +1,283 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Text.Json.Serialization;
+
+namespace JsonFlatFileDataStore;
+
+public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
+{
+    public override ExpandoObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+        {
+            var root = doc.RootElement;
+
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                var expando = new ExpandoObject();
+                var dictionary = (IDictionary<string, object>)expando;
+
+                foreach (var property in root.EnumerateObject())
+                {
+                    AddPropertyToExpando(dictionary, property.Name, property.Value);
+                }
+
+                return expando;
+            }
+
+            throw new JsonException("Invalid JSON: Expected JSON object.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, ExpandoObject value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, (object)value, options);
+    }
+
+    private static void AddPropertyToExpando(IDictionary<string, object> expando, string propertyName, JsonElement propertyValue)
+    {
+        switch (propertyValue.ValueKind)
+        {
+            case JsonValueKind.Undefined:
+            case JsonValueKind.Null:
+                expando[propertyName] = null;
+                break;
+
+            case JsonValueKind.False:
+                expando[propertyName] = false;
+                break;
+
+            case JsonValueKind.True:
+                expando[propertyName] = true;
+                break;
+
+            case JsonValueKind.Number:
+                if (propertyValue.TryGetInt32(out int intValue))
+                {
+                    expando[propertyName] = intValue;
+                }
+                else if (propertyValue.TryGetInt64(out long longValue))
+                {
+                    expando[propertyName] = longValue;
+                }
+                else if (propertyValue.TryGetDouble(out double doubleValue))
+                {
+                    expando[propertyName] = doubleValue;
+                }
+                else if (propertyValue.TryGetDecimal(out decimal decimalValue))
+                {
+                    expando[propertyName] = decimalValue;
+                }
+                else
+                {
+                    // TODO: Handle other numeric types as needed
+                    throw new JsonException("Unsupported numeric type");
+                }
+                break;
+
+            case JsonValueKind.String:
+                // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
+                // Newtonsoft.Json automatically parsed strings that looked like dates
+                expando[propertyName] = TryParseDateTime(propertyValue.GetString());
+                break;
+
+            case JsonValueKind.Object:
+                var nestedExpando = new ExpandoObject();
+                var nestedDictionary = (IDictionary<string, object>)nestedExpando;
+                foreach (var nestedProperty in propertyValue.EnumerateObject())
+                {
+                    AddPropertyToExpando(nestedDictionary, nestedProperty.Name, nestedProperty.Value);
+                }
+                expando[propertyName] = nestedExpando;
+                break;
+
+            case JsonValueKind.Array:
+                var arrayValues = new List<object>();
+                foreach (var arrayElement in propertyValue.EnumerateArray())
+                {
+                    switch (arrayElement.ValueKind)
+                    {
+                        case JsonValueKind.Undefined:
+                        case JsonValueKind.Null:
+                            arrayValues.Add(null);
+                            break;
+
+                        case JsonValueKind.False:
+                            arrayValues.Add(false);
+                            break;
+
+                        case JsonValueKind.True:
+                            arrayValues.Add(true);
+                            break;
+
+                        case JsonValueKind.Number:
+                            if (arrayElement.TryGetInt32(out int arrayElementIntValue))
+                            {
+                                arrayValues.Add(arrayElementIntValue);
+                            }
+                            else if (arrayElement.TryGetInt64(out long longValue))
+                            {
+                                arrayValues.Add(longValue);
+                            }
+                            else if (arrayElement.TryGetDouble(out double doubleValue))
+                            {
+                                arrayValues.Add(doubleValue);
+                            }
+                            else if (arrayElement.TryGetDecimal(out decimal decimalValue))
+                            {
+                                arrayValues.Add(decimalValue);
+                            }
+                            else
+                            {
+                                throw new JsonException("Unsupported numeric type");
+                            }
+                            break;
+
+                        case JsonValueKind.String:
+                            // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
+                            arrayValues.Add(TryParseDateTime(arrayElement.GetString()));
+                            break;
+
+                        case JsonValueKind.Object:
+                            var nestedExpandoInArray = new ExpandoObject();
+                            var nestedDictionaryInArray = (IDictionary<string, object>)nestedExpandoInArray;
+                            foreach (var nestedPropertyInArray in arrayElement.EnumerateObject())
+                            {
+                                AddPropertyToExpando(nestedDictionaryInArray, nestedPropertyInArray.Name, nestedPropertyInArray.Value);
+                            }
+                            arrayValues.Add(nestedExpandoInArray);
+                            break;
+
+                        case JsonValueKind.Array:
+                            // Recursively handle nested arrays
+                            var nestedArray = new List<object>();
+                            foreach (var nestedArrayElement in arrayElement.EnumerateArray())
+                            {
+                                switch (nestedArrayElement.ValueKind)
+                                {
+                                    case JsonValueKind.Undefined:
+                                    case JsonValueKind.Null:
+                                        nestedArray.Add(null);
+                                        break;
+
+                                    case JsonValueKind.False:
+                                        nestedArray.Add(false);
+                                        break;
+
+                                    case JsonValueKind.True:
+                                        nestedArray.Add(true);
+                                        break;
+
+                                    case JsonValueKind.Number:
+                                        if (nestedArrayElement.TryGetInt32(out int nestedArrayElementIntValue))
+                                        {
+                                            nestedArray.Add(nestedArrayElementIntValue);
+                                        }
+                                        else if (nestedArrayElement.TryGetInt64(out long longValue))
+                                        {
+                                            nestedArray.Add(longValue);
+                                        }
+                                        else if (nestedArrayElement.TryGetDouble(out double doubleValue))
+                                        {
+                                            nestedArray.Add(doubleValue);
+                                        }
+                                        else if (nestedArrayElement.TryGetDecimal(out decimal decimalValue))
+                                        {
+                                            nestedArray.Add(decimalValue);
+                                        }
+                                        else
+                                        {
+                                            throw new JsonException("Unsupported numeric type");
+                                        }
+                                        break;
+
+                                    case JsonValueKind.String:
+                                        // Try to parse as DateTime to maintain Newtonsoft.Json compatibility
+                                        nestedArray.Add(TryParseDateTime(nestedArrayElement.GetString()));
+                                        break;
+
+                                    case JsonValueKind.Object:
+
+                                        var nestedExpandoInNestedArray = new ExpandoObject();
+                                        var nestedDictionaryInNestedArray = (IDictionary<string, object>)nestedExpandoInNestedArray;
+                                        foreach (var nestedPropertyInNestedArray in nestedArrayElement.EnumerateObject())
+                                        {
+                                            AddPropertyToExpando(nestedDictionaryInNestedArray,
+                                                nestedPropertyInNestedArray.Name,
+                                                nestedPropertyInNestedArray.Value);
+                                        }
+                                        nestedArray.Add(nestedExpandoInNestedArray);
+                                        break;
+
+                                    case JsonValueKind.Array:
+                                        // Recursively handle deeper nested arrays
+                                        nestedArray.Add(ProcessNestedArray(nestedArrayElement));
+                                        break;
+
+                                }
+                            }
+                            arrayValues.Add(nestedArray);
+                            break;
+                    }
+                }
+                expando[propertyName] = arrayValues;
+                break;
+        }
+    }
+
+    private static object ProcessNestedArray(JsonElement arrayElement)
+    {
+        var arrayValues = new List<object>();
+
+        foreach (var element in arrayElement.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                var nestedExpando = new ExpandoObject();
+                var nestedDictionary = (IDictionary<string, object>)nestedExpando;
+                foreach (var nestedProperty in element.EnumerateObject())
+                {
+                    AddPropertyToExpando(nestedDictionary, nestedProperty.Name, nestedProperty.Value);
+                }
+                arrayValues.Add(nestedExpando);
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                // Recursively handle further nested arrays
+                arrayValues.Add(ProcessNestedArray(element));
+            }
+            else
+            {
+                arrayValues.Add(element.ToString());
+            }
+        }
+
+        return arrayValues;
+    }
+
+    /// <summary>
+    /// Try to parse a string as DateTime to maintain backward compatibility with Newtonsoft.Json
+    /// Newtonsoft.Json automatically parsed strings that looked like dates
+    ///
+    /// Performance Note: This method is called for every string value when deserializing
+    /// dynamic/ExpandoObject data. DateTime.TryParse() has a performance cost, but it's
+    /// necessary to maintain backward compatibility. For performance-critical scenarios,
+    /// consider using strongly-typed collections (GetCollection&lt;T&gt;()) which don't
+    /// require this parsing step.
+    /// </summary>
+    private static object TryParseDateTime(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        // Try to parse as DateTime using standard formats
+        // This includes ISO 8601, RFC 1123, and common date formats
+        if (DateTime.TryParse(value, out DateTime dateTime))
+        {
+            return dateTime;
+        }
+
+        // If not a valid date, return as string
+        return value;
+    }
+}

--- a/JsonFlatFileDataStore/ExpandoObjectConverter.cs
+++ b/JsonFlatFileDataStore/ExpandoObjectConverter.cs
@@ -32,7 +32,7 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
 
     public override void Write(Utf8JsonWriter writer, ExpandoObject value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, (object)value, options);
+        JsonSerializer.Serialize(writer, (IDictionary<string, object>)value, options);
     }
 
     private static void AddPropertyToExpando(IDictionary<string, object> expando, string propertyName, JsonElement propertyValue)
@@ -221,24 +221,49 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
 
         foreach (var element in arrayElement.EnumerateArray())
         {
-            if (element.ValueKind == JsonValueKind.Object)
+            switch (element.ValueKind)
             {
-                var nestedExpando = new ExpandoObject();
-                var nestedDictionary = (IDictionary<string, object>)nestedExpando;
-                foreach (var nestedProperty in element.EnumerateObject())
-                {
-                    AddPropertyToExpando(nestedDictionary, nestedProperty.Name, nestedProperty.Value);
-                }
-                arrayValues.Add(nestedExpando);
-            }
-            else if (element.ValueKind == JsonValueKind.Array)
-            {
-                // Recursively handle further nested arrays
-                arrayValues.Add(ProcessNestedArray(element));
-            }
-            else
-            {
-                arrayValues.Add(element.ToString());
+                case JsonValueKind.Object:
+                    var nestedExpando = new ExpandoObject();
+                    var nestedDictionary = (IDictionary<string, object>)nestedExpando;
+                    foreach (var nestedProperty in element.EnumerateObject())
+                    {
+                        AddPropertyToExpando(nestedDictionary, nestedProperty.Name, nestedProperty.Value);
+                    }
+                    arrayValues.Add(nestedExpando);
+                    break;
+
+                case JsonValueKind.Array:
+                    arrayValues.Add(ProcessNestedArray(element));
+                    break;
+
+                case JsonValueKind.Undefined:
+                case JsonValueKind.Null:
+                    arrayValues.Add(null);
+                    break;
+
+                case JsonValueKind.False:
+                    arrayValues.Add(false);
+                    break;
+
+                case JsonValueKind.True:
+                    arrayValues.Add(true);
+                    break;
+
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out long longValue))
+                        arrayValues.Add(longValue);
+                    else if (element.TryGetDouble(out double doubleValue))
+                        arrayValues.Add(doubleValue);
+                    else if (element.TryGetDecimal(out decimal decimalValue))
+                        arrayValues.Add(decimalValue);
+                    else
+                        throw new JsonException("Unsupported numeric type");
+                    break;
+
+                case JsonValueKind.String:
+                    arrayValues.Add(TryParseDateTime(element.GetString()));
+                    break;
             }
         }
 

--- a/JsonFlatFileDataStore/ExpandoObjectConverter.cs
+++ b/JsonFlatFileDataStore/ExpandoObjectConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
 using System.Text.Json.Serialization;
 
 namespace JsonFlatFileDataStore;
@@ -52,11 +53,9 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
                 break;
 
             case JsonValueKind.Number:
-                if (propertyValue.TryGetInt32(out int intValue))
-                {
-                    expando[propertyName] = intValue;
-                }
-                else if (propertyValue.TryGetInt64(out long longValue))
+                // Newtonsoft.Json deserialized JSON integers as Int64 for dynamic/ExpandoObject mode;
+                // preserve that behavior so dynamic arithmetic and type assertions stay stable.
+                if (propertyValue.TryGetInt64(out long longValue))
                 {
                     expando[propertyName] = longValue;
                 }
@@ -70,7 +69,6 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
                 }
                 else
                 {
-                    // TODO: Handle other numeric types as needed
                     throw new JsonException("Unsupported numeric type");
                 }
                 break;
@@ -111,21 +109,17 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
                             break;
 
                         case JsonValueKind.Number:
-                            if (arrayElement.TryGetInt32(out int arrayElementIntValue))
+                            if (arrayElement.TryGetInt64(out long arrLong))
                             {
-                                arrayValues.Add(arrayElementIntValue);
+                                arrayValues.Add(arrLong);
                             }
-                            else if (arrayElement.TryGetInt64(out long longValue))
+                            else if (arrayElement.TryGetDouble(out double arrDouble))
                             {
-                                arrayValues.Add(longValue);
+                                arrayValues.Add(arrDouble);
                             }
-                            else if (arrayElement.TryGetDouble(out double doubleValue))
+                            else if (arrayElement.TryGetDecimal(out decimal arrDecimal))
                             {
-                                arrayValues.Add(doubleValue);
-                            }
-                            else if (arrayElement.TryGetDecimal(out decimal decimalValue))
-                            {
-                                arrayValues.Add(decimalValue);
+                                arrayValues.Add(arrDecimal);
                             }
                             else
                             {
@@ -169,21 +163,17 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
                                         break;
 
                                     case JsonValueKind.Number:
-                                        if (nestedArrayElement.TryGetInt32(out int nestedArrayElementIntValue))
+                                        if (nestedArrayElement.TryGetInt64(out long nestLong))
                                         {
-                                            nestedArray.Add(nestedArrayElementIntValue);
+                                            nestedArray.Add(nestLong);
                                         }
-                                        else if (nestedArrayElement.TryGetInt64(out long longValue))
+                                        else if (nestedArrayElement.TryGetDouble(out double nestDouble))
                                         {
-                                            nestedArray.Add(longValue);
+                                            nestedArray.Add(nestDouble);
                                         }
-                                        else if (nestedArrayElement.TryGetDouble(out double doubleValue))
+                                        else if (nestedArrayElement.TryGetDecimal(out decimal nestDecimal))
                                         {
-                                            nestedArray.Add(doubleValue);
-                                        }
-                                        else if (nestedArrayElement.TryGetDecimal(out decimal decimalValue))
-                                        {
-                                            nestedArray.Add(decimalValue);
+                                            nestedArray.Add(nestDecimal);
                                         }
                                         else
                                         {
@@ -265,19 +255,31 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
     /// consider using strongly-typed collections (GetCollection&lt;T&gt;()) which don't
     /// require this parsing step.
     /// </summary>
+    private static readonly string[] _dateTimeFormats = new[]
+    {
+        "yyyy-MM-ddTHH:mm:ss.FFFFFFFK",
+        "yyyy-MM-ddTHH:mm:ss.FFFFFFF",
+        "yyyy-MM-ddTHH:mm:ssK",
+        "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-dd"
+    };
+
     private static object TryParseDateTime(string value)
     {
         if (string.IsNullOrEmpty(value))
             return value;
 
-        // Try to parse as DateTime using standard formats
-        // This includes ISO 8601, RFC 1123, and common date formats
-        if (DateTime.TryParse(value, out DateTime dateTime))
+        // Only parse strings that match an explicit ISO 8601 date(time) format.
+        // DateTime.TryParse is too permissive — it would treat "01:30:00" (TimeSpan) or
+        // "12.5" (a version-like string) as DateTime by attaching today's date.
+        foreach (var format in _dateTimeFormats)
         {
-            return dateTime;
+            if (DateTime.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt))
+                return dt;
+            if (DateTime.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt))
+                return dt;
         }
 
-        // If not a valid date, return as string
         return value;
     }
 }

--- a/JsonFlatFileDataStore/ExpandoObjectConverter.cs
+++ b/JsonFlatFileDataStore/ExpandoObjectConverter.cs
@@ -289,7 +289,7 @@ public class SystemExpandoObjectConverter : JsonConverter<ExpandoObject>
         "yyyy-MM-dd"
     };
 
-    private static object TryParseDateTime(string value)
+    internal static object TryParseDateTime(string value)
     {
         if (string.IsNullOrEmpty(value))
             return value;

--- a/JsonFlatFileDataStore/GlobalUsings.cs
+++ b/JsonFlatFileDataStore/GlobalUsings.cs
@@ -1,1 +1,2 @@
 ﻿global using System;
+global using System.Text.Json;

--- a/JsonFlatFileDataStore/IDataStore.cs
+++ b/JsonFlatFileDataStore/IDataStore.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 using System.Threading.Tasks;
 
 namespace JsonFlatFileDataStore;
-
 /// <summary>
 /// JSON data store
 /// </summary>

--- a/JsonFlatFileDataStore/IDocumentCollection.cs
+++ b/JsonFlatFileDataStore/IDocumentCollection.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Dynamic;
 using System.Threading.Tasks;
 
 namespace JsonFlatFileDataStore;
-
 /// <summary>
 /// Collection of items
 /// </summary>

--- a/JsonFlatFileDataStore/JsonFlatFileDataStore.csproj
+++ b/JsonFlatFileDataStore/JsonFlatFileDataStore.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/ttu/json-flatfile-datastore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Version>2.4.2</Version>
-    <Company/>
+    <Company />
     <Description>Simple JSON flat file data store</Description>
     <PackageTags>json flat file data store database linq</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -31,13 +31,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
-    <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/JsonFlatFileDataStore/JsonFlatFileDataStore.csproj
+++ b/JsonFlatFileDataStore/JsonFlatFileDataStore.csproj
@@ -32,12 +32,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+    <PackageReference Include="System.Text.Json" Version="10.0.0"/>
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
-    <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/JsonFlatFileDataStore/NewtonsoftDateTimeConverter.cs
+++ b/JsonFlatFileDataStore/NewtonsoftDateTimeConverter.cs
@@ -1,0 +1,68 @@
+﻿using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace JsonFlatFileDataStore;
+/// <summary>
+/// Custom DateTime converter for System.Text.Json that provides compatibility with Newtonsoft.Json DateTime formats.
+///
+/// This converter was created during the migration from Newtonsoft.Json to System.Text.Json to handle
+/// DateTime strings that were serialized by Newtonsoft.Json, particularly the format "yyyy-MM-ddTHH:mm:ss"
+/// without timezone designators, which System.Text.Json's default converter doesn't support.
+///
+/// Supported formats:
+/// - "yyyy-MM-ddTHH:mm:ss.FFFFFFFK" (full precision with timezone)
+/// - "yyyy-MM-ddTHH:mm:ss.FFFFFFF" (full precision without timezone)
+/// - "yyyy-MM-ddTHH:mm:ssK" (seconds with timezone)
+/// - "yyyy-MM-ddTHH:mm:ss" (seconds without timezone - Newtonsoft.Json default)
+/// - "yyyy-MM-dd" (date only)
+/// </summary>
+public class NewtonsoftDateTimeConverter : JsonConverter<DateTime>
+{
+    private readonly string _defaultFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK"; // ISO 8601 format
+
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            string dateString = reader.GetString();
+
+            // Common formats to try
+            string[] formats = new[]
+            {
+            "yyyy-MM-ddTHH:mm:ss.FFFFFFFK",  // Full precision with timezone
+            "yyyy-MM-ddTHH:mm:ss.FFFFFFF",   // Full precision without timezone
+            "yyyy-MM-ddTHH:mm:ssK",          // Seconds with timezone
+            "yyyy-MM-ddTHH:mm:ss",           // Seconds without timezone (Newtonsoft default)
+            "yyyy-MM-dd"                     // Date only
+        };
+
+            // Try parsing with various formats
+            foreach (var format in formats)
+            {
+                // Try with RoundtripKind first (for formats with timezone)
+                if (DateTime.TryParseExact(dateString, format, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime date))
+                {
+                    return date;
+                }
+                // Try without RoundtripKind for formats without timezone
+                if (DateTime.TryParseExact(dateString, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+                {
+                    return date;
+                }
+            }
+
+            // Last resort: try general parsing
+            if (DateTime.TryParse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime parsedDate))
+            {
+                return parsedDate;
+            }
+        }
+        throw new JsonException($"Invalid date format: {reader.GetString()}");
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        // Write DateTime in ISO 8601 format (default for Newtonsoft.Json)
+        writer.WriteStringValue(value.ToString(_defaultFormat, CultureInfo.InvariantCulture));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ collection2.ReplaceOne((Predicate<dynamic>)(e => e.id == 11), dynamicUser);
 
 ### Decimal precision
 
-Large `decimal` values do not survive a round trip cleanly. Data is internally routed through `ExpandoObject`, which represents JSON numbers as `double`, so anything past roughly 15 significant digits becomes inexact. `decimal.MaxValue` is a worst case — it is written in scientific notation (`7.922816251426434E+28`) that cannot be parsed back as `decimal` at all, and reading the file raises `JsonReaderException`.
+Large `decimal` values do not survive a round trip cleanly. Data is internally routed through `ExpandoObject`, which represents JSON numbers as `double`, so anything past roughly 15 significant digits becomes inexact. `decimal.MaxValue` is a worst case — it is written in scientific notation (`7.922816251426434E+28`) that cannot be parsed back as `decimal` at all, and reading the file raises `System.Text.Json.JsonException` (in earlier Newtonsoft-based releases this surfaced as `Newtonsoft.Json.JsonReaderException`).
 
 If you need exact preservation of large or high-precision decimals, store them as strings. Pinned by `NumericEdgeCaseTests`.
 
@@ -801,6 +801,31 @@ These features were built-in to Newtonsoft.Json but require custom implementatio
 * **Case-insensitive property matching**: Both versions support case-insensitive property updates (e.g., updating `Age` will correctly update `age`).
 * **Performance considerations**: Custom parsing logic for backward compatibility (automatic date parsing and case-insensitive property matching) may impact performance with large dynamic datasets. Use strongly-typed collections (`GetCollection<T>()`) for better performance when possible.
 * **Implementation note**: Features like automatic date parsing and case-insensitive property updates were built-in to Newtonsoft.Json but required custom implementation for System.Text.Json to maintain backward compatibility.
+
+### Known Behavior Differences
+
+The following differences were uncovered while migrating the test suite. Most are intrinsic to `System.Text.Json` and are not papered over by the compatibility shims:
+
+| Area | Newtonsoft.Json | System.Text.Json (this library) | Notes |
+| --- | --- | --- | --- |
+| Whole-number `double` output | `5.0` | `5` | STJ drops the trailing `.0`. Numeric value is unchanged. Pinned by `JsonOutputFormatTests.GoldenFile_DoubleFormatting_FivePointZero_WrittenCorrectly`. |
+| Invalid-JSON exception type | `Newtonsoft.Json.JsonException` | `System.Text.Json.JsonException` (typically the `JsonReaderException` subtype) | Callers catching the old type must update. |
+| `JToken` / `JObject` / `JArray` inputs | Accepted directly | Replaced by `JsonNode` / `JsonObject` / `JsonArray` from `System.Text.Json.Nodes` | The library accepts `JsonNode`-typed inputs in the same shape; rewrite call sites accordingly. |
+| Enum-as-string on typed models | `[JsonConverter(typeof(StringEnumConverter))]` | `[JsonConverter(typeof(JsonStringEnumConverter))]` | Read path also registers a global `JsonStringEnumConverter` (camelCase, case-insensitive). |
+| Dynamic integer type | All JSON integers surface as `Int64` (`long`) | Same — preserved by the custom `ExpandoObject` converter (Int64 is tried before smaller widths) | Without the converter STJ would surface them as `Int32`. |
+| Dynamic string → DateTime promotion | Permissive (`DateTime.TryParse`) | Restricted to explicit ISO 8601 patterns (`yyyy-MM-dd[THH:mm:ss[.FFFFFFF]][K]`) | Prevents `TimeSpan`-shaped strings like `"01:30:00"` from being silently turned into "today at 01:30". |
+| `TimeSpan` round-trip on typed models | Stored as `"hh:mm:ss[.fff]"` | Same on write (STJ default); read requires the typed deserialization path | Pinned by `TemporalAndIdentifierTests.TimeSpan_RoundTrip`. |
+| `DateTime.Kind = Utc` on single items | Preserved | Preserved (after the dynamic-string-promotion fix above) | Without the stricter promotion, UTC values were silently rewritten with the local offset. |
+| `DateTimeOffset` round-trip | Preserved | Preserved | Pinned by `TemporalAndIdentifierTests.DateTimeOffset_RoundTrip`. |
+| Large `decimal` values | Preserved within `decimal` precision | **Lossy** — routed through `ExpandoObject`/`double`, so >~15 significant digits are inexact and `decimal.MaxValue` cannot round-trip at all | Pre-existing limitation, see **Known Limitations** above. Store as `string` for exact preservation. |
+| `JsonNode` indexer return type | `JToken` had implicit conversion operators (`(int)token["id"]` worked) | `JsonNode` requires explicit `GetValue<T>()` (e.g. `node["id"].GetValue<int>()`) | Affects user code that reads `JsonNode`. Library-returned dynamic values are unaffected — they surface as primitives or `ExpandoObject`. |
+| Case-insensitive property binding (typed read) | Built-in | Enabled here via `PropertyNameCaseInsensitive = true` on the typed deserializer | Pre-existing files with PascalCase keys still load into camelCase models. Pinned by `CaseSensitivityTests`. |
+| Case-insensitive property merge (dynamic update) | Built-in | Custom implementation in `ObjectExtensions` — matching is `OrdinalIgnoreCase`, the existing key's casing is preserved | Updating `"Age"` correctly overwrites an existing `"age"` entry without creating a duplicate. |
+| `Dictionary<TKey, TValue>` with non-string keys (`int`, `Guid`, `enum`) | Supported out of the box | Supported on `System.Text.Json` 6+ when round-tripping through the library's options; keys are serialized as JSON strings | Pinned by `DictionarySerializationTests`. |
+| `[JsonConverter]` attribute namespace | `Newtonsoft.Json.JsonConverter` | `System.Text.Json.Serialization.JsonConverter` | Custom converters from the Newtonsoft world must be rewritten against the STJ converter API. |
+| `double.NaN` / `±Infinity` | Written as quoted literals (`"NaN"`, `"Infinity"`, `"-Infinity"`) | Same — enabled here via `JsonNumberHandling.AllowNamedFloatingPointLiterals`. STJ's default would throw on serialize. | Without the opt-in flag the commit thread would throw and the synchronous `InsertItem` call would hang waiting for a Ready callback. Both the flag and a defensive `try`/`catch` around each `HandleAction` in `CommitActionHandler` are required. Pinned by `NumericEdgeCaseTests.Double_NaN_RoundTrip_BehaviorPinned` and `Double_Infinity_RoundTrip_BehaviorPinned`. |
+
+## Unit Tests & Benchmarks
 
 ## Unit Tests & Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A lightweight, JSON-based data storage solution, ideal for small applications an
 * .NET implementation & version support: [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version)
   * For example, .NET 6, .NET Core 2.0, .NET Framework 4.6.1
 
+**Major Version Changes**
+
+* Version 3.0: Uses `System.Text.Json` instead of `Newtonsoft.Json` for JSON serialization and deserialization. This change reduces dependencies, as `System.Text.Json` is part of the .NET runtime.
+
 **Docs Website**
 
 [https://ttu.github.io/json-flatfile-datastore/](https://ttu.github.io/json-flatfile-datastore/)
@@ -692,9 +696,111 @@ Large `decimal` values do not survive a round trip cleanly. Data is internally r
 
 If you need exact preservation of large or high-precision decimals, store them as strings. Pinned by `NumericEdgeCaseTests`.
 
-## C# Language Version
+## System.Text.Json vs Newtonsoft.Json
 
-The main library (`JsonFlatFileDataStore`) uses C# 10 language features and targets .NET Standard 2.0. Most C# 10 features are compiler-only and work with .NET Standard 2.0. However, some C# 10 features require runtime support and are not compatible with .NET Standard 2.0.
+Starting from version 3.x, JSON Flat File Data Store uses `System.Text.Json` instead of `Newtonsoft.Json` for JSON serialization and deserialization. This change reduces external dependencies, as `System.Text.Json` is part of the .NET runtime.
+
+**Note**: To maintain backward compatibility with Newtonsoft.Json behavior, custom parsing logic has been implemented for:
+- **Automatic date parsing** for dynamic types (parsing date strings to DateTime)
+- **Case-insensitive property matching** when updating ExpandoObjects (e.g., updating `Age` correctly updates `age`)
+
+These features were built-in to Newtonsoft.Json but required custom implementation in System.Text.Json. This may have a slight performance impact compared to using System.Text.Json without custom converters. For performance-critical applications, consider using strongly-typed collections.
+
+### Key Differences for Users
+
+#### 1. Working with Dynamic JSON Objects
+
+**Newtonsoft.Json (versions < 3.0):**
+```csharp
+// JToken/JObject had implicit conversion operators
+var employeeJson = JToken.Parse("{ \"id\": 1, \"name\": \"John\" }");
+await collection.InsertOneAsync(employeeJson);
+
+// Direct comparison worked due to implicit conversions
+Assert.Equal(1, employeeJson["id"]);
+```
+
+**System.Text.Json (version 3.x+):**
+```csharp
+// JsonNode is the equivalent of JToken
+var employeeJson = JsonNode.Parse("{ \"id\": 1, \"name\": \"John\" }");
+await collection.InsertOneAsync(employeeJson);
+
+// Explicit conversion required using GetValue<T>()
+Assert.Equal(1, employeeJson["id"].GetValue<int>());
+Assert.Equal("John", employeeJson["name"].GetValue<string>());
+```
+
+#### 2. Dynamic Data Types Support
+
+Both versions support the same dynamic data types:
+* `Anonymous types`
+* `ExpandoObject`
+* `Dictionary<string, object>`
+* JSON objects:
+  * versions < 3.0: `JToken`, `JObject`, `JArray` (Newtonsoft.Json)
+  * version 3.x+: `JsonNode`, `JsonObject`, `JsonArray` (System.Text.Json)
+
+#### 3. Creating Update Data
+
+**Newtonsoft.Json (versions < 3.0):**
+```csharp
+var patchData = new Dictionary<string, object>
+{
+    { "Age", 41 },
+    { "Name", "James" }
+};
+var jobject = JObject.FromObject(patchData);
+dynamic patchExpando = JsonConvert.DeserializeObject<ExpandoObject>(jobject.ToString());
+
+await collection.UpdateOneAsync(e => e.Id == 12, patchExpando);
+```
+
+**System.Text.Json (version 3.x+):**
+```csharp
+var patchData = new Dictionary<string, object>
+{
+    { "Age", 41 },
+    { "Name", "James" }
+};
+var jsonString = JsonSerializer.Serialize(patchData);
+var options = new JsonSerializerOptions { Converters = { new SystemExpandoObjectConverter() } };
+dynamic patchExpando = JsonSerializer.Deserialize<ExpandoObject>(jsonString, options);
+
+await collection.UpdateOneAsync(e => e.Id == 12, patchExpando);
+```
+
+#### 4. Date Handling with Dynamic Types
+
+Both versions automatically parse date strings when using dynamic types:
+
+```csharp
+// Both Newtonsoft.Json and System.Text.Json automatically parse date strings
+dynamic itemDynamic = store.GetItem("myDate");
+// itemDynamic is automatically converted to DateTime
+int year = itemDynamic.Year; // Works in both versions!
+
+// Typed retrieval also works as expected
+var itemTyped = store.GetItem<DateTime>("myDate");
+int year = itemTyped.Year; // Works!
+```
+
+**Performance Note**: In version 3.x, to maintain backward compatibility with Newtonsoft.Json, custom logic has been implemented for:
+1. **Automatic date parsing**: For **dynamic types only**, attempts to parse all string values as dates using `DateTime.TryParse()`. This performance impact **only affects dynamic/ExpandoObject collections** - typed collections (`GetCollection<T>()`) only parse strings that are actually mapped to DateTime properties, making them more efficient.
+2. **Case-insensitive property matching**: When updating ExpandoObjects, finds existing properties using case-insensitive comparison
+
+These features were built-in to Newtonsoft.Json but require custom implementation in System.Text.Json. The date parsing performance impact **only affects dynamic types** - if performance is critical, use strongly-typed collections (`GetCollection<T>()`) where possible.
+
+### Migration Notes
+
+* **API remains the same**: Public APIs for collections and data store operations are unchanged.
+* **JSON parsing**: Replace `JToken.Parse()` with `JsonNode.Parse()`.
+* **Value extraction**: Use `.GetValue<T>()` when accessing values from `JsonNode`.
+* **Date handling**: Both versions automatically parse date strings to DateTime for dynamic types (backward compatible).
+* **Converters**: If you were using custom Newtonsoft.Json converters, you'll need to rewrite them for System.Text.Json.
+* **Case-insensitive property matching**: Both versions support case-insensitive property updates (e.g., updating `Age` will correctly update `age`).
+* **Performance considerations**: Custom parsing logic for backward compatibility (automatic date parsing and case-insensitive property matching) may impact performance with large dynamic datasets. Use strongly-typed collections (`GetCollection<T>()`) for better performance when possible.
+* **Implementation note**: Features like automatic date parsing and case-insensitive property updates were built-in to Newtonsoft.Json but required custom implementation for System.Text.Json to maintain backward compatibility.
 
 ## Unit Tests & Benchmarks
 
@@ -708,6 +814,10 @@ Run benchmarks from the command line:
 ```sh
 $ dotnet run --configuration Release --project JsonFlatFileDataStore.Benchmark\JsonFlatFileDataStore.Benchmark.csproj
 ```
+
+## C# Language Version
+
+The main library (`JsonFlatFileDataStore`) uses C# 10 language features and targets .NET Standard 2.0. Most C# 10 features are compiler-only and work with .NET Standard 2.0. However, some C# 10 features require runtime support and are not compatible with .NET Standard 2.0.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ var counter = await store.GetItem<int>("counter");
 Dynamic data can be any of the following types:
 * `Anonymous type`
 * `ExpandoObject`
-* JSON objects (`JToken`, `JObject`, `JArray`)
+* JSON objects (`JsonNode`, `JsonObject`, `JsonArray`)
 * `Dictionary<string, object>`
 
 Note: All dynamic data is internally serialized to `ExpandoObject`.
@@ -114,7 +114,7 @@ var collection = store.GetCollection("employee");
 var employee = new { id = 1, name = "John", age = 46 };
 
 // Create new employee from JSON
-var employeeJson = JToken.Parse("{ 'id': 2, 'name': 'Raymond', 'age': 32 }");
+var employeeJson = JsonNode.Parse("{ \"id\": 2, \"name\": \"Raymond\", \"age\": 32 }");
 
 // Create new employee from dictionary
 var employeeDict = new Dictionary<string, object>
@@ -134,7 +134,7 @@ await collection.InsertOneAsync(employeeDict);
 var updateData = new { name = "John Doe" };
 
 // Update data from JSON
-var updateJson = JToken.Parse("{ 'name': 'Raymond Doe' }");
+var updateJson = JsonNode.Parse("{ \"name\": \"Raymond Doe\" }");
 
 // Update data from dictionary
 var updateDict = new Dictionary<string, object> { ["name"] = "Andy Doe" };
@@ -227,7 +227,7 @@ var caseSensitiveMatches = collection.Find("Alabama", true);
 await collection.InsertOneAsync(new { id = 3, name = "Raymond", age = 32, city = "NY" });
 
 // Dynamic item can also be JSON object
-var user = JToken.Parse("{ 'id': 3, 'name': 'Raymond', 'age': 32, 'city': 'NY' }");
+var user = JsonNode.Parse("{ \"id\": 3, \"name\": \"Raymond\", \"age\": 32, \"city\": \"NY\" }");
 await collection.InsertOneAsync(user);
 
 // Synchronous method and typed data
@@ -266,14 +266,14 @@ If the type of the `id`-field is a *number*, the value is incremented by one. If
 
 ```csharp
 // Latest id in the collection is "hello5"
-var user = JToken.Parse("{ 'id': 'wrongValue', 'name': 'Raymond', 'age': 32, 'city': 'NY' }");
+var user = JsonNode.Parse("{ \"id\": \"wrongValue\", \"name\": \"Raymond\", \"age\": 32, \"city\": \"NY\" }");
 await collection.InsertOneAsync(user);
-// After addition: user["id"] == "hello6"
+// After addition: user["id"].GetValue<string>() == "hello6"
 
 // User data doesn't have an id field
-var userNoId = JToken.Parse("{ 'name': 'Raymond', 'age': 32, 'city': 'NY' }");
+var userNoId = JsonNode.Parse("{ \"name\": \"Raymond\", \"age\": 32, \"city\": \"NY\" }");
 await collection.InsertOneAsync(userNoId);
-// After addition: userNoId["id"] == "hello7"
+// After addition: userNoId["id"].GetValue<string>() == "hello7"
 ```
 
 For an empty collection, if the `id`-field's type is a number, the first id will be `0`. If the type is a string, the first id will be `"0"`.
@@ -376,8 +376,9 @@ patchData.Add("Age", 41);
 patchData.Add("Name", "James");
 patchData.Add("Work", new Dictionary<string, object> { { "Name", "ACME" } });
 
-var jobject = JObject.FromObject(patchData);
-dynamic patchExpando = JsonConvert.DeserializeObject<ExpandoObject>(jobject.ToString());
+var jsonString = JsonSerializer.Serialize(patchData);
+var options = new JsonSerializerOptions { Converters = { new SystemExpandoObjectConverter() } };
+dynamic patchExpando = JsonSerializer.Deserialize<ExpandoObject>(jsonString, options);
 
 await collection.UpdateOneAsync(e => e.Id == 12, patchExpando);
 ```
@@ -809,7 +810,7 @@ The following differences were uncovered while migrating the test suite. Most ar
 | Area | Newtonsoft.Json | System.Text.Json (this library) | Notes |
 | --- | --- | --- | --- |
 | Whole-number `double` output | `5.0` | `5` | STJ drops the trailing `.0`. Numeric value is unchanged. Pinned by `JsonOutputFormatTests.GoldenFile_DoubleFormatting_FivePointZero_WrittenCorrectly`. |
-| Invalid-JSON exception type | `Newtonsoft.Json.JsonException` | `System.Text.Json.JsonException` (typically the `JsonReaderException` subtype) | Callers catching the old type must update. |
+| Invalid-JSON exception type | `Newtonsoft.Json.JsonException` | `System.Text.Json.JsonException` | Callers catching the old type must update. |
 | `JToken` / `JObject` / `JArray` inputs | Accepted directly | Replaced by `JsonNode` / `JsonObject` / `JsonArray` from `System.Text.Json.Nodes` | The library accepts `JsonNode`-typed inputs in the same shape; rewrite call sites accordingly. |
 | Enum-as-string on typed models | `[JsonConverter(typeof(StringEnumConverter))]` | `[JsonConverter(typeof(JsonStringEnumConverter))]` | Read path also registers a global `JsonStringEnumConverter` (camelCase, case-insensitive). |
 | Dynamic integer type | All JSON integers surface as `Int64` (`long`) | Same — preserved by the custom `ExpandoObject` converter (Int64 is tried before smaller widths) | Without the converter STJ would surface them as `Int32`. |
@@ -824,8 +825,6 @@ The following differences were uncovered while migrating the test suite. Most ar
 | `Dictionary<TKey, TValue>` with non-string keys (`int`, `Guid`, `enum`) | Supported out of the box | Supported on `System.Text.Json` 6+ when round-tripping through the library's options; keys are serialized as JSON strings | Pinned by `DictionarySerializationTests`. |
 | `[JsonConverter]` attribute namespace | `Newtonsoft.Json.JsonConverter` | `System.Text.Json.Serialization.JsonConverter` | Custom converters from the Newtonsoft world must be rewritten against the STJ converter API. |
 | `double.NaN` / `±Infinity` | Written as quoted literals (`"NaN"`, `"Infinity"`, `"-Infinity"`) | Same — enabled here via `JsonNumberHandling.AllowNamedFloatingPointLiterals`. STJ's default would throw on serialize. | Without the opt-in flag the commit thread would throw and the synchronous `InsertItem` call would hang waiting for a Ready callback. Both the flag and a defensive `try`/`catch` around each `HandleAction` in `CommitActionHandler` are required. Pinned by `NumericEdgeCaseTests.Double_NaN_RoundTrip_BehaviorPinned` and `Double_Infinity_RoundTrip_BehaviorPinned`. |
-
-## Unit Tests & Benchmarks
 
 ## Unit Tests & Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -691,11 +691,11 @@ collection2.ReplaceOne((Predicate<dynamic>)(e => e.id == 11), dynamicUser);
 
 ## Known Limitations
 
-### Decimal precision
+### Decimal precision (dynamic reads only)
 
-Large `decimal` values do not survive a round trip cleanly. Data is internally routed through `ExpandoObject`, which represents JSON numbers as `double`, so anything past roughly 15 significant digits becomes inexact. `decimal.MaxValue` is a worst case — it is written in scientific notation (`7.922816251426434E+28`) that cannot be parsed back as `decimal` at all, and reading the file raises `System.Text.Json.JsonException` (in earlier Newtonsoft-based releases this surfaced as `Newtonsoft.Json.JsonReaderException`).
+Since version 3.x, `decimal` values are written to disk verbatim — the write path no longer routes data through `ExpandoObject`/`double`. Values are stored exactly (`decimal.MaxValue` is written as `79228162514264337593543950335`, not scientific notation) and **typed** round-trips (`GetCollection<T>()`) preserve the full value, including large and high-precision decimals.
 
-If you need exact preservation of large or high-precision decimals, store them as strings. Pinned by `NumericEdgeCaseTests`.
+The remaining caveat is **dynamic** access: `GetCollection()` / `GetItem()` surface JSON numbers through `ExpandoObject`, which represents non-integer numbers as `double` (matching Newtonsoft's dynamic behavior), so a decimal read this way loses precision beyond roughly 15 significant digits. If you need the exact `decimal`, read through a typed collection. Pinned by `NumericEdgeCaseTests`.
 
 ## System.Text.Json vs Newtonsoft.Json
 
@@ -773,21 +773,22 @@ await collection.UpdateOneAsync(e => e.Id == 12, patchExpando);
 
 #### 4. Date Handling with Dynamic Types
 
-Both versions automatically parse date strings when using dynamic types:
+When using dynamic types, string values are promoted to `DateTime` **only** when they match an explicit ISO 8601 date/time pattern:
 
 ```csharp
-// Both Newtonsoft.Json and System.Text.Json automatically parse date strings
+// Stored value must be ISO 8601, e.g. "2015-11-23" or "2015-11-23T00:00:00"
 dynamic itemDynamic = store.GetItem("myDate");
-// itemDynamic is automatically converted to DateTime
-int year = itemDynamic.Year; // Works in both versions!
+// itemDynamic is a DateTime
+int year = itemDynamic.Year;
 
-// Typed retrieval also works as expected
+// Typed retrieval is permissive — the caller declared the type, so even a
+// non-ISO/locale-specific value like "6/15/2009" is parsed to DateTime.
 var itemTyped = store.GetItem<DateTime>("myDate");
-int year = itemTyped.Year; // Works!
+int typedYear = itemTyped.Year;
 ```
 
-**Performance Note**: In version 3.x, to maintain backward compatibility with Newtonsoft.Json, custom logic has been implemented for:
-1. **Automatic date parsing**: For **dynamic types only**, attempts to parse all string values as dates using `DateTime.TryParse()`. This performance impact **only affects dynamic/ExpandoObject collections** - typed collections (`GetCollection<T>()`) only parse strings that are actually mapped to DateTime properties, making them more efficient.
+**Performance Note**: In version 3.x, to approximate Newtonsoft.Json's convenience, custom logic has been implemented for:
+1. **Automatic date parsing**: For **dynamic types only**, string values that match an explicit ISO 8601 pattern (`yyyy-MM-dd[THH:mm:ss[.FFFFFFF]][K]`) are promoted to `DateTime` via `DateTime.TryParseExact` (invariant culture). Non-ISO strings — including locale-specific formats like `6/15/2009` and `TimeSpan`-shaped values like `01:30:00` — are left as strings. This applies identically to the collection (`GetCollection`) and single-item (`GetItem`) dynamic paths, and is independent of the machine's locale. The parsing cost **only affects dynamic/ExpandoObject collections** — typed collections (`GetCollection<T>()`) only parse strings mapped to `DateTime` properties, making them more efficient.
 2. **Case-insensitive property matching**: When updating ExpandoObjects, finds existing properties using case-insensitive comparison
 
 These features were built-in to Newtonsoft.Json but require custom implementation in System.Text.Json. The date parsing performance impact **only affects dynamic types** - if performance is critical, use strongly-typed collections (`GetCollection<T>()`) where possible.
@@ -797,7 +798,7 @@ These features were built-in to Newtonsoft.Json but require custom implementatio
 * **API remains the same**: Public APIs for collections and data store operations are unchanged.
 * **JSON parsing**: Replace `JToken.Parse()` with `JsonNode.Parse()`.
 * **Value extraction**: Use `.GetValue<T>()` when accessing values from `JsonNode`.
-* **Date handling**: Both versions automatically parse date strings to DateTime for dynamic types (backward compatible).
+* **Date handling**: For dynamic types, only explicit ISO 8601 date/time strings are promoted to `DateTime`. Newtonsoft's more permissive parsing (e.g. `6/15/2009`) is intentionally *not* reproduced, to avoid misinterpreting locale-ambiguous or `TimeSpan`-shaped strings. Typed reads (`GetItem<DateTime>` / `DateTime` properties) still parse permissively.
 * **Converters**: If you were using custom Newtonsoft.Json converters, you'll need to rewrite them for System.Text.Json.
 * **Case-insensitive property matching**: Both versions support case-insensitive property updates (e.g., updating `Age` will correctly update `age`).
 * **Performance considerations**: Custom parsing logic for backward compatibility (automatic date parsing and case-insensitive property matching) may impact performance with large dynamic datasets. Use strongly-typed collections (`GetCollection<T>()`) for better performance when possible.
@@ -818,7 +819,7 @@ The following differences were uncovered while migrating the test suite. Most ar
 | `TimeSpan` round-trip on typed models | Stored as `"hh:mm:ss[.fff]"` | Same on write (STJ default); read requires the typed deserialization path | Pinned by `TemporalAndIdentifierTests.TimeSpan_RoundTrip`. |
 | `DateTime.Kind = Utc` on single items | Preserved | Preserved (after the dynamic-string-promotion fix above) | Without the stricter promotion, UTC values were silently rewritten with the local offset. |
 | `DateTimeOffset` round-trip | Preserved | Preserved | Pinned by `TemporalAndIdentifierTests.DateTimeOffset_RoundTrip`. |
-| Large `decimal` values | Preserved within `decimal` precision | **Lossy** — routed through `ExpandoObject`/`double`, so >~15 significant digits are inexact and `decimal.MaxValue` cannot round-trip at all | Pre-existing limitation, see **Known Limitations** above. Store as `string` for exact preservation. |
+| Large `decimal` values | Preserved within `decimal` precision | Stored exactly and preserved by typed round-trips (`GetCollection<T>()`), including `decimal.MaxValue`; only **dynamic** reads surface as `double` and lose precision beyond ~15 significant digits | See **Known Limitations** above. Use a typed collection for exact preservation. Pinned by `NumericEdgeCaseTests`. |
 | `JsonNode` indexer return type | `JToken` had implicit conversion operators (`(int)token["id"]` worked) | `JsonNode` requires explicit `GetValue<T>()` (e.g. `node["id"].GetValue<int>()`) | Affects user code that reads `JsonNode`. Library-returned dynamic values are unaffected — they surface as primitives or `ExpandoObject`. |
 | Case-insensitive property binding (typed read) | Built-in | Enabled here via `PropertyNameCaseInsensitive = true` on the typed deserializer | Pre-existing files with PascalCase keys still load into camelCase models. Pinned by `CaseSensitivityTests`. |
 | Case-insensitive property merge (dynamic update) | Built-in | Custom implementation in `ObjectExtensions` — matching is `OrdinalIgnoreCase`, the existing key's casing is preserved | Updating `"Age"` correctly overwrites an existing `"age"` entry without creating a duplicate. |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A lightweight, JSON-based data storage solution, ideal for small applications an
 
 **Major Version Changes**
 
-* Version 3.0: Uses `System.Text.Json` instead of `Newtonsoft.Json` for JSON serialization and deserialization. This change reduces dependencies, as `System.Text.Json` is part of the .NET runtime.
+* Version 3.0: Uses `System.Text.Json` instead of `Newtonsoft.Json` for JSON serialization and deserialization. `System.Text.Json` is included in modern .NET runtimes, so on those it is not an extra dependency. The `netstandard2.0` target still pulls it in through the `System.Text.Json` package reference in `JsonFlatFileDataStore.csproj`.
 
 **Docs Website**
 


### PR DESCRIPTION
Implement https://github.com/ttu/json-flatfile-datastore/issues/101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Migrated JSON handling from Newtonsoft.Json to System.Text.Json, including dynamic JSON inputs.
  * Updated behaviors for **DateTime parsing**, **decimal precision**, numeric formatting, and exception types.
  * Dynamic/patch updates now use case-insensitive property matching when applying updates.

* **New Features / Enhancements**
  * Added System.Text.Json converters for dynamic objects and standardized DateTime serialization.
  * Added a public helper to locate JSON paths.

* **Bug Fixes / Quality**
  * Improved robustness around JSON parsing during concurrent access.
  * Added a disposal/no-memory-leak test.

* **Documentation**
  * Updated the migration guide for System.Text.Json behavior differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->