### PR TITLE
test: expand test coverage with behavior pinning and edge case suites

### DIFF
--- a/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
+++ b/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
@@ -27,6 +27,10 @@ public class BehaviorPinningTests
         Assert.Equal(1, fresh.Count);
         Assert.Equal(99, (int)(long)fresh.AsQueryable().First().id);
 
+        // Pin: the previously-obtained reference still holds the pre-UpdateAll snapshot.
+        Assert.Equal(1, collection.Count);
+        Assert.Equal(1, (int)(long)collection.AsQueryable().First().id);
+
         store.Dispose();
         UTHelpers.Down(path);
     }

--- a/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
+++ b/JsonFlatFileDataStore.Test/BehaviorPinningTests.cs
@@ -1,0 +1,119 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Pin current Newtonsoft-specific quirks of the library so the migration to
+/// System.Text.Json must explicitly match or document a deliberate change.
+/// </summary>
+public class BehaviorPinningTests
+{
+    [Fact]
+    public async Task UpdateAll_ExistingCollectionRef_BehaviorPinned()
+    {
+        var path = UTHelpers.GetFullFilePath($"UpdAllRef_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("user");
+        await collection.InsertOneAsync(new { id = 1, name = "Original" });
+        Assert.Equal(1, collection.Count);
+
+        store.UpdateAll("{ \"user\": [ { \"id\": 99, \"name\": \"Replaced\" } ] }");
+
+        // The previously-obtained collection reference uses a Lazy<List<T>> snapshot
+        // and does not see UpdateAll changes. A freshly obtained collection does.
+        var fresh = store.GetCollection("user");
+        Assert.Equal(1, fresh.Count);
+        Assert.Equal(99, (int)(long)fresh.AsQueryable().First().id);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void AnonymousType_IdZero_BehaviorPinned()
+    {
+        // Anonymous type with explicit id = 0 (default int). Pin whether the library
+        // overwrites this or treats 0 as a "real" id and keeps it.
+        var path = UTHelpers.GetFullFilePath($"AnonIdZero_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("items");
+        collection.InsertOne(new { id = 0, name = "First" });
+        collection.InsertOne(new { id = 0, name = "Second" });
+
+        var items = collection.AsQueryable().ToList();
+        Assert.Equal(2, items.Count);
+
+        // Both items keep id = 0 (the user-provided value is trusted for anonymous types
+        // that already include the id field).
+        Assert.All(items, e => Assert.Equal(0, (int)(long)e.id));
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void AnonymousType_StringIdNonNumeric_BehaviorPinned()
+    {
+        // ParseNextIntegerToKeyValue handles non-numeric string ids by appending "0".
+        var path = UTHelpers.GetFullFilePath($"AnonStrId_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, keyProperty: "code");
+
+        var collection = store.GetCollection("items");
+        collection.InsertOne(new { code = "abc", label = "First" });
+
+        var nextId = collection.GetNextIdValue();
+        Assert.Equal("abc0", nextId);
+
+        collection.InsertOne(new { label = "Second" });
+
+        var nextId2 = collection.GetNextIdValue();
+        Assert.Equal("abc1", nextId2);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EnumStringConverter_BehaviorPinned()
+    {
+        // A typed model attribute-decorated to serialize an enum as a string.
+        // Pin whether such a custom converter survives a round trip via the library.
+        var path = UTHelpers.GetFullFilePath($"EnumStr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<ModelWithStringEnum>("model");
+        await collection.InsertOneAsync(new ModelWithStringEnum { Id = 1, Status = StatusValue.Active });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Newtonsoft honors the [JsonConverter] attribute — value is written as a string.
+        Assert.Contains("\"Active\"", json);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<ModelWithStringEnum>("model").AsQueryable().First();
+        Assert.Equal(StatusValue.Active, item.Status);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    public enum StatusValue
+    {
+        Inactive,
+        Active,
+        Pending
+    }
+
+    public class ModelWithStringEnum
+    {
+        public int Id { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public StatusValue Status { get; set; }
+    }
+}

--- a/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
+++ b/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
@@ -1,0 +1,71 @@
+using System.IO;
+
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Newtonsoft is case-insensitive when binding JSON property names to typed model
+/// properties. System.Text.Json is case-sensitive by default. These tests pin
+/// the current lenient read behavior so the migration must explicitly opt in or document a break.
+/// </summary>
+public class CaseSensitivityTests
+{
+    [Fact]
+    public void ReadExistingFile_PascalCaseKeys_WithCamelCaseSetting_StillReadable()
+    {
+        var path = UTHelpers.GetFullFilePath($"PascalIn_{DateTime.UtcNow.Ticks}");
+
+        // File written outside this library, using Pascal case for property names
+        File.WriteAllText(path, "{ \"user\": [ { \"Id\": 1, \"Name\": \"Alice\", \"Age\": 30 } ] }");
+
+        var store = new DataStore(path, useLowerCamelCase: true);
+        var collection = store.GetCollection<User>("user");
+        var user = collection.AsQueryable().First();
+
+        Assert.Equal(1, user.Id);
+        Assert.Equal("Alice", user.Name);
+        Assert.Equal(30, user.Age);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void ReadExistingFile_MixedCaseKeys_BehaviorPinned()
+    {
+        var path = UTHelpers.GetFullFilePath($"MixedIn_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path, "{ \"user\": [ { \"id\": 1, \"NAME\": \"BOB\", \"age\": 40 } ] }");
+
+        var store = new DataStore(path, useLowerCamelCase: true);
+        var collection = store.GetCollection<User>("user");
+        var user = collection.AsQueryable().First();
+
+        Assert.Equal(1, user.Id);
+        Assert.Equal("BOB", user.Name);
+        Assert.Equal(40, user.Age);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void ReadExistingFile_DynamicAccess_CaseSensitive()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynCase_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path, "{ \"user\": [ { \"id\": 1, \"Name\": \"Alice\" } ] }");
+
+        var store = new DataStore(path, useLowerCamelCase: true);
+        var collection = store.GetCollection("user");
+        var user = collection.AsQueryable().First();
+
+        // Dynamic access reflects the JSON keys verbatim — no implicit case folding.
+        var dict = user as IDictionary<string, object>;
+        Assert.NotNull(dict);
+        Assert.True(dict.ContainsKey("Name"));
+        Assert.False(dict.ContainsKey("name"));
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/CollectionInsertBatchTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionInsertBatchTests.cs
@@ -85,4 +85,25 @@ public class CollectionInsertBatchTests
 
         UTHelpers.Down(newFilePath);
     }
+
+    [Fact]
+    public async Task ConcurrentInserts_AllItemsPersisted()
+    {
+        var path = UTHelpers.GetFullFilePath($"Concurrent_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+        var collection = store.GetCollection("items");
+
+        const int count = 50;
+        var tasks = Enumerable.Range(0, count)
+            .Select(i => collection.InsertOneAsync(new { id = i, value = $"item{i}" }));
+
+        await Task.WhenAll(tasks);
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        Assert.Equal(count, store2.GetCollection("items").Count);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
 }

--- a/JsonFlatFileDataStore.Test/CollectionModificationTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionModificationTests.cs
@@ -1071,4 +1071,113 @@ public class CollectionModificationTests
 
         UTHelpers.Down(newFilePath);
     }
+
+    [Fact]
+    public async Task ReplaceManyAsync_NoMatch_ReturnsFalse()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+        var collection = store.GetCollection<User>("user");
+
+        var result = await collection.ReplaceManyAsync(e => e.Name == "DoesNotExist", new User { Id = 99, Name = "Nobody" });
+        Assert.False(result);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public async Task ReplaceManyAsync_SingleMatch_ReplacesItem()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+        var collection = store.GetCollection<User>("user");
+
+        var result = await collection.ReplaceManyAsync(e => e.Name == "Phil", new User { Id = 1, Name = "Phillip" });
+        Assert.True(result);
+
+        var store2 = new DataStore(newFilePath);
+        var collection2 = store2.GetCollection<User>("user");
+        Assert.Single(collection2.AsQueryable(), e => e.Name == "Phillip");
+        Assert.DoesNotContain(collection2.AsQueryable(), e => e.Name == "Phil");
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public async Task ReplaceManyAsync_MultipleMatches_ReplacesAll()
+    {
+        var path = UTHelpers.GetFullFilePath($"ReplaceManyAsync_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+        var collection = store.GetCollection<User>("user");
+
+        await collection.InsertOneAsync(new User { Id = 10, Name = "Target", Age = 20 });
+        await collection.InsertOneAsync(new User { Id = 11, Name = "Target", Age = 25 });
+        await collection.InsertOneAsync(new User { Id = 12, Name = "Other", Age = 30 });
+
+        var result = await collection.ReplaceManyAsync(e => e.Name == "Target", new User { Id = 0, Name = "Replaced", Age = 99 });
+        Assert.True(result);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<User>("user");
+        var replaced = collection2.AsQueryable().Where(e => e.Name == "Replaced").ToList();
+        Assert.Equal(2, replaced.Count);
+        Assert.All(replaced, u => Assert.Equal(99, u.Age));
+        Assert.Single(collection2.AsQueryable(), e => e.Name == "Other");
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task ReplaceManyAsync_PersistsAfterReload()
+    {
+        var path = UTHelpers.GetFullFilePath($"ReplaceManyAsyncPersist_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+        var collection = store.GetCollection<User>("user");
+
+        await collection.InsertOneAsync(new User { Id = 1, Name = "Before", Age = 10 });
+        await collection.InsertOneAsync(new User { Id = 2, Name = "Before", Age = 20 });
+
+        await collection.ReplaceManyAsync(e => e.Name == "Before", new User { Id = 1, Name = "After", Age = 50 });
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var all = store2.GetCollection<User>("user").AsQueryable().ToList();
+        Assert.Equal(2, all.Count);
+        Assert.All(all, u => Assert.Equal("After", u.Name));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task UpdateOne_DynamicWithExpandoObject_PreservesExistingFields()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynExpUpd_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("users");
+        await collection.InsertOneAsync(new { id = 1, name = "Alice", age = 30, location = "NY" });
+
+        // Update only age using ExpandoObject
+        dynamic update = new ExpandoObject();
+        update.age = 31;
+        await collection.UpdateOneAsync(e => e.id == 1, update as object);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("users");
+        var user = collection2.AsQueryable().First();
+
+        // Age should be updated, other fields preserved
+        Assert.Equal("Alice", (string)user.name);
+        Assert.Equal(31, (int)(long)user.age);
+        Assert.Equal("NY", (string)user.location);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
 }

--- a/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
@@ -290,4 +290,24 @@ public class CollectionQueryTests
 
         UTHelpers.Down(newFilePath);
     }
+
+    [Fact]
+    public void ExpandoObject_CastToIDictionary_Works()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("user");
+        var user = collection.AsQueryable().First();
+
+        // The dynamic item should be castable to IDictionary<string, object>
+        // This is critical because ObjectExtensions relies on this cast
+        var dict = user as IDictionary<string, object>;
+        Assert.NotNull(dict);
+        Assert.True(dict.ContainsKey("name"));
+        Assert.True(dict.ContainsKey("id"));
+        Assert.Equal("James", dict["name"]);
+
+        UTHelpers.Down(newFilePath);
+    }
 }

--- a/JsonFlatFileDataStore.Test/DictionarySerializationTests.cs
+++ b/JsonFlatFileDataStore.Test/DictionarySerializationTests.cs
@@ -1,0 +1,260 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Tests for Dictionary serialization, especially Dictionary with non-string keys
+/// (int, Guid, enum) which System.Text.Json does NOT support by default.
+/// Pin the current Newtonsoft round-trip behavior here.
+/// </summary>
+public class DictionarySerializationTests
+{
+    public class GuidKeyModel
+    {
+        public int Id { get; set; }
+        public Dictionary<Guid, string> Lookup { get; set; }
+    }
+
+    public class EnumKeyModel
+    {
+        public int Id { get; set; }
+        public Dictionary<Gender, int> Counts { get; set; }
+    }
+
+    [Fact]
+    public async Task DictionaryStringString_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictStrStr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<PrivateOwner>("owner");
+        await collection.InsertOneAsync(new PrivateOwner
+        {
+            FirstName = "Alice",
+            OwnerLongTestProperty = "Test",
+            MyValues = new List<int> { 1, 2, 3 },
+            MyStrings = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" },
+                { "key3", "value3" }
+            },
+            MyIntegers = new Dictionary<int, int>()
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<PrivateOwner>("owner");
+        var owner = collection2.AsQueryable().First();
+
+        Assert.Equal("Alice", owner.FirstName);
+        Assert.Equal(3, owner.MyStrings.Count);
+        Assert.Equal("value1", owner.MyStrings["key1"]);
+        Assert.Equal("value2", owner.MyStrings["key2"]);
+        Assert.Equal("value3", owner.MyStrings["key3"]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DictionaryIntInt_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictIntInt_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<PrivateOwner>("owner");
+        await collection.InsertOneAsync(new PrivateOwner
+        {
+            FirstName = "Bob",
+            OwnerLongTestProperty = "Test",
+            MyValues = new List<int> { 10, 20 },
+            MyStrings = new Dictionary<string, string>(),
+            MyIntegers = new Dictionary<int, int>
+            {
+                { 1, 100 },
+                { 2, 200 },
+                { 3, 300 }
+            }
+        });
+
+        store.Dispose();
+
+        // This is the critical test: System.Text.Json does not natively support
+        // Dictionary<int, int> keys — they must be serialized as strings in JSON
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<PrivateOwner>("owner");
+        var owner = collection2.AsQueryable().First();
+
+        Assert.Equal("Bob", owner.FirstName);
+        Assert.Equal(3, owner.MyIntegers.Count);
+        Assert.Equal(100, owner.MyIntegers[1]);
+        Assert.Equal(200, owner.MyIntegers[2]);
+        Assert.Equal(300, owner.MyIntegers[3]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DictionaryIntInt_JsonRepresentation()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictIntJson_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<PrivateOwner>("owner");
+        await collection.InsertOneAsync(new PrivateOwner
+        {
+            FirstName = "Charlie",
+            OwnerLongTestProperty = "X",
+            MyValues = new List<int>(),
+            MyStrings = new Dictionary<string, string>(),
+            MyIntegers = new Dictionary<int, int> { { 42, 999 } }
+        });
+
+        // Verify the JSON file has the dictionary serialized
+        var json = UTHelpers.GetFileContent(path);
+        Assert.Contains("42", json);
+        Assert.Contains("999", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DictionaryUpdate_CopyProperties_Works()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictUpdate_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<PrivateOwner>("owner");
+        await collection.InsertOneAsync(new PrivateOwner
+        {
+            FirstName = "Dave",
+            OwnerLongTestProperty = "Original",
+            MyValues = new List<int> { 1 },
+            MyStrings = new Dictionary<string, string> { { "a", "1" } },
+            MyIntegers = new Dictionary<int, int> { { 1, 10 } }
+        });
+
+        // Update with new dictionary values
+        await collection.UpdateOneAsync(
+            e => e.FirstName == "Dave",
+            new
+            {
+                MyStrings = new Dictionary<string, string> { { "b", "2" }, { "c", "3" } },
+                MyIntegers = new Dictionary<int, int> { { 5, 50 }, { 6, 60 } }
+            });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<PrivateOwner>("owner");
+        var owner = collection2.AsQueryable().First();
+
+        Assert.Equal(2, owner.MyStrings.Count);
+        Assert.Equal("2", owner.MyStrings["b"]);
+        Assert.Equal("3", owner.MyStrings["c"]);
+        Assert.Equal(2, owner.MyIntegers.Count);
+        Assert.Equal(50, owner.MyIntegers[5]);
+        Assert.Equal(60, owner.MyIntegers[6]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EmptyDictionaries_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictEmpty_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<PrivateOwner>("owner");
+        await collection.InsertOneAsync(new PrivateOwner
+        {
+            FirstName = "Eve",
+            OwnerLongTestProperty = "Test",
+            MyValues = new List<int>(),
+            MyStrings = new Dictionary<string, string>(),
+            MyIntegers = new Dictionary<int, int>()
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<PrivateOwner>("owner");
+        var owner = collection2.AsQueryable().First();
+
+        Assert.NotNull(owner.MyStrings);
+        Assert.Empty(owner.MyStrings);
+        Assert.NotNull(owner.MyIntegers);
+        Assert.Empty(owner.MyIntegers);
+        Assert.NotNull(owner.MyValues);
+        Assert.Empty(owner.MyValues);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Dictionary_GuidKey_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictGuid_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var k1 = Guid.NewGuid();
+        var k2 = Guid.NewGuid();
+
+        var collection = store.GetCollection<GuidKeyModel>("model");
+        await collection.InsertOneAsync(new GuidKeyModel
+        {
+            Id = 1,
+            Lookup = new Dictionary<Guid, string>
+            {
+                { k1, "first" },
+                { k2, "second" }
+            }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<GuidKeyModel>("model").AsQueryable().First();
+
+        Assert.Equal(2, item.Lookup.Count);
+        Assert.Equal("first", item.Lookup[k1]);
+        Assert.Equal("second", item.Lookup[k2]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Dictionary_EnumKey_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DictEnum_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<EnumKeyModel>("model");
+        await collection.InsertOneAsync(new EnumKeyModel
+        {
+            Id = 1,
+            Counts = new Dictionary<Gender, int>
+            {
+                { Gender.Male, 10 },
+                { Gender.Female, 20 }
+            }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<EnumKeyModel>("model").AsQueryable().First();
+
+        Assert.Equal(2, item.Counts.Count);
+        Assert.Equal(10, item.Counts[Gender.Male]);
+        Assert.Equal(20, item.Counts[Gender.Female]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/DynamicAccessEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/DynamicAccessEdgeCaseTests.cs
@@ -1,0 +1,88 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Edge cases for DataStore.GetItem when the value is an array (of objects, of arrays, mixed).
+/// SingleDynamicItemReadConverter handles JArray by returning List&lt;object&gt; — pin the resulting
+/// element types so the migration produces compatible structures.
+/// </summary>
+public class DynamicAccessEdgeCaseTests
+{
+    [Fact]
+    public void GetItem_DynamicArrayOfObjects()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynArrObj_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var things = new[]
+        {
+            new { id = 1, label = "A" },
+            new { id = 2, label = "B" },
+            new { id = 3, label = "C" }
+        };
+        store.InsertItem("things", things);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var dyn = store2.GetItem("things");
+
+        var list = dyn as System.Collections.IList;
+        Assert.NotNull(list);
+        Assert.Equal(3, list.Count);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void GetItem_DynamicNestedArray()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynNestArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("matrix", new[]
+        {
+            new[] { 1, 2, 3 },
+            new[] { 4, 5, 6 },
+            new[] { 7, 8, 9 }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var dyn = store2.GetItem("matrix");
+
+        var outer = dyn as System.Collections.IList;
+        Assert.NotNull(outer);
+        Assert.Equal(3, outer.Count);
+
+        // Round-trip through typed read for the actual value check (more stable).
+        var typed = store2.GetItem<List<List<int>>>("matrix");
+        Assert.Equal(3, typed.Count);
+        Assert.Equal(new List<int> { 1, 2, 3 }, typed[0]);
+        Assert.Equal(new List<int> { 7, 8, 9 }, typed[2]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void GetItem_EmptyArray_ReturnsEmptyList()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynEmptyArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("empty", new int[] { });
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var dyn = store2.GetItem("empty");
+
+        var list = dyn as System.Collections.IList;
+        Assert.NotNull(list);
+        Assert.Empty(list);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/FileAccessTests.cs
+++ b/JsonFlatFileDataStore.Test/FileAccessTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+
+namespace JsonFlatFileDataStore.Test;
+
+public class FileAccessTests
+{
+    // WriteJsonToFile — catch (Exception) return false path
+    [Fact]
+    public void WriteJsonToFile_DirectoryDoesNotExist_ReturnsFalse()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid()}", "file.json");
+        var result = FileAccess.WriteJsonToFile(path, s => s, "{}");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void WriteJsonToFile_ValidPath_ReturnsTrue()
+    {
+        var path = UTHelpers.GetFullFilePath($"FAWrite_{DateTime.UtcNow.Ticks}");
+        var result = FileAccess.WriteJsonToFile(path, s => s, "{\"test\":1}");
+        Assert.True(result);
+        Assert.Equal("{\"test\":1}", File.ReadAllText(path));
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void WriteJsonToFile_EncryptTransformApplied()
+    {
+        var path = UTHelpers.GetFullFilePath($"FAEnc_{DateTime.UtcNow.Ticks}");
+        var result = FileAccess.WriteJsonToFile(path, s => s + "SUFFIX", "{}");
+        Assert.True(result);
+        Assert.Equal("{}SUFFIX", File.ReadAllText(path));
+        UTHelpers.Down(path);
+    }
+
+    // ReadJsonFromFile — FileNotFoundException creates file
+    [Fact]
+    public void ReadJsonFromFile_FileNotFound_CreatesFileAndReturnsEmptyObject()
+    {
+        var path = UTHelpers.GetFullFilePath($"FARead_{DateTime.UtcNow.Ticks}");
+        Assert.False(File.Exists(path));
+
+        var content = FileAccess.ReadJsonFromFile(path, s => s, s => s);
+
+        Assert.True(File.Exists(path));
+        Assert.Equal("{}", content);
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void ReadJsonFromFile_ExistingFile_ReturnsContent()
+    {
+        var path = UTHelpers.GetFullFilePath($"FAReadExist_{DateTime.UtcNow.Ticks}");
+        File.WriteAllText(path, "{\"key\":42}");
+
+        var content = FileAccess.ReadJsonFromFile(path, s => s, s => s);
+
+        Assert.Equal("{\"key\":42}", content);
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void ReadJsonFromFile_DecryptTransformApplied()
+    {
+        var path = UTHelpers.GetFullFilePath($"FADecrypt_{DateTime.UtcNow.Ticks}");
+        File.WriteAllText(path, "ENCRYPTED");
+
+        var content = FileAccess.ReadJsonFromFile(path, s => s, s => "DECRYPTED");
+
+        Assert.Equal("DECRYPTED", content);
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/JTokenInputTests.cs
+++ b/JsonFlatFileDataStore.Test/JTokenInputTests.cs
@@ -1,0 +1,118 @@
+using Newtonsoft.Json.Linq;
+
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Pin behavior of public APIs that accept Newtonsoft JToken/JObject/JArray as input.
+/// Migration to System.Text.Json must decide: keep these as a compatibility shim
+/// or drop them as a breaking change. These tests lock the contract before that decision.
+/// </summary>
+public class JTokenInputTests
+{
+    [Fact]
+    public async Task InsertOne_JToken_AnonymousObject_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"JTInsert_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var token = JToken.Parse("{ 'id': 1, 'name': 'Alice', 'age': 30 }");
+
+        var collection = store.GetCollection("user");
+        await collection.InsertOneAsync(token);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var user = store2.GetCollection("user").AsQueryable().First();
+
+        Assert.Equal(1, (int)(long)user.id);
+        Assert.Equal("Alice", (string)user.name);
+        Assert.Equal(30, (int)(long)user.age);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task UpdateOne_JTokenPatch_AppliesCorrectly()
+    {
+        var path = UTHelpers.GetFullFilePath($"JTUpdate_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("user");
+        await collection.InsertOneAsync(new { id = 1, name = "Original", age = 20, location = "NY" });
+
+        var patch = JToken.Parse("{ 'name': 'Patched', 'age': 25 }");
+        var updated = await collection.UpdateOneAsync((Predicate<dynamic>)(e => e.id == 1), patch);
+        Assert.True(updated);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var user = store2.GetCollection("user").AsQueryable().First();
+
+        Assert.Equal("Patched", (string)user.name);
+        Assert.Equal(25, (int)(long)user.age);
+        Assert.Equal("NY", (string)user.location);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task ReplaceOne_JObject_NestedJArray()
+    {
+        var path = UTHelpers.GetFullFilePath($"JTReplace_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("things");
+        await collection.InsertOneAsync(new { id = 1, label = "old", tags = new[] { "a" } });
+
+        var replacement = new JObject
+        {
+            ["id"] = 1,
+            ["label"] = "new",
+            ["tags"] = new JArray { "x", "y", "z" },
+            ["nested"] = new JArray { new JArray { 1, 2 }, new JArray { 3, 4 } }
+        };
+
+        var ok = await collection.ReplaceOneAsync((Predicate<dynamic>)(e => e.id == 1), replacement);
+        Assert.True(ok);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection("things").AsQueryable().First();
+
+        Assert.Equal("new", (string)item.label);
+        Assert.Equal(3, ((System.Collections.IList)item.tags).Count);
+        Assert.Equal("x", (string)item.tags[0]);
+        Assert.Equal(2, ((System.Collections.IList)item.nested).Count);
+        Assert.Equal(2, (int)(long)item.nested[0][1]);
+        Assert.Equal(4, (int)(long)item.nested[1][1]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task InsertMany_JTokenArray_AllItemsInserted()
+    {
+        var path = UTHelpers.GetFullFilePath($"JTMany_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var json = "[ { 'id': 1, 'name': 'A' }, { 'id': 2, 'name': 'B' }, { 'id': 3, 'name': 'C' } ]";
+        var array = JToken.Parse(json);
+
+        var collection = store.GetCollection("items");
+        await collection.InsertManyAsync(array);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        Assert.Equal(3, store2.GetCollection("items").Count);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
+++ b/JsonFlatFileDataStore.Test/JsonOutputFormatTests.cs
@@ -1,0 +1,276 @@
+using System.Text.RegularExpressions;
+
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Golden file / exact JSON output tests to catch formatting differences
+/// between serializers (property order, number formatting, whitespace).
+/// Some tests use byte-equivalent assertions — the migration to System.Text.Json must either
+/// produce identical output for these inputs, or the assertion is updated and the diff is
+/// consciously accepted as part of the migration PR.
+/// </summary>
+public class JsonOutputFormatTests
+{
+    [Fact]
+    public async Task Golden_Minified_TypedModel_ExactBytes()
+    {
+        var path = UTHelpers.GetFullFilePath($"GoldMini_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection<Movie>("movie");
+        await collection.InsertOneAsync(new Movie { Name = "Predator", Rating = 7.5 });
+        await collection.InsertOneAsync(new Movie { Name = "Aliens", Rating = 8.4 });
+
+        store.Dispose();
+
+        var actual = UTHelpers.GetFileContent(path);
+        const string expected = "{\"movie\":[{\"name\":\"Predator\",\"rating\":7.5},{\"name\":\"Aliens\",\"rating\":8.4}]}";
+
+        Assert.Equal(expected, actual);
+
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Golden_Indented_SingleItem_ExactBytes()
+    {
+        var path = UTHelpers.GetFullFilePath($"GoldInd_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true);
+
+        await store.InsertItemAsync("counter", 42);
+
+        store.Dispose();
+
+        var actual = UTHelpers.GetFileContent(path).Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // Indented output, lower camel case key. The two-space indent matches Newtonsoft's
+        // Formatting.Indented default. Pin the structure here — body content, not just substrings.
+        const string expected = "{\n  \"counter\": 42\n}";
+        Assert.Equal(expected, actual);
+
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Golden_Minified_NestedDynamicObject_ExactBytes()
+    {
+        var path = UTHelpers.GetFullFilePath($"GoldNest_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection("user");
+        await collection.InsertOneAsync(new
+        {
+            id = 1,
+            name = "Alice",
+            work = new { name = "ACME", location = "NY" }
+        });
+
+        store.Dispose();
+
+        var actual = UTHelpers.GetFileContent(path);
+        const string expected = "{\"user\":[{\"id\":1,\"name\":\"Alice\",\"work\":{\"name\":\"ACME\",\"location\":\"NY\"}}]}";
+
+        Assert.Equal(expected, actual);
+
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_Minified()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Mini_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection<Movie>("movie");
+        await collection.InsertOneAsync(new Movie { Name = "X", Rating = 1.0 });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Minified should have no newlines or indentation
+        Assert.DoesNotContain("\n", json);
+        Assert.DoesNotContain("  ", json);
+
+        // But should still have correct content
+        Assert.Contains("\"movie\"", json);
+        Assert.Contains("\"name\":\"X\"", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_NestedObject_PropertyOrder()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Nested_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "Alice",
+            Age = 30,
+            Location = "NY",
+            Work = new WorkPlace { Name = "ACME", Location = "NY" }
+        });
+
+        var json = UTHelpers.GetFileContent(path);
+        var normalized = json.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // Verify nested object structure
+        Assert.Contains("\"work\":", normalized);
+        Assert.Contains("\"name\": \"ACME\"", normalized);
+        Assert.Contains("\"location\": \"NY\"", normalized);
+
+        // Verify all property names are lowerCamelCase
+        Assert.DoesNotContain("\"Id\":", normalized);
+        Assert.DoesNotContain("\"Name\":", normalized);
+        Assert.DoesNotContain("\"Age\":", normalized);
+        Assert.DoesNotContain("\"Work\":", normalized);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_IntegerFormatting()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Int_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection("items");
+        await collection.InsertOneAsync(new { id = 1, count = 0, big = 999999 });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Integers should not have decimal points
+        Assert.Matches(new Regex("\"id\":1[,}\\]]"), json);
+        Assert.Matches(new Regex("\"count\":0[,}\\]]"), json);
+        Assert.Contains("999999", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_BooleanFormatting()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Bool_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        store.InsertItem("active", true);
+        store.InsertItem("deleted", false);
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Booleans should be lowercase true/false (not True/False or 1/0)
+        Assert.Contains("true", json);
+        Assert.Contains("false", json);
+        Assert.DoesNotContain("True", json);
+        Assert.DoesNotContain("False", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_NullFormatting()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Null_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "Test",
+            Age = 25,
+            Location = null,
+            Work = null
+        });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Null values should be serialized as the JSON literal null
+        Assert.Contains("null", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_EmptyArray()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_EmptyArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true, minifyJson: true);
+
+        var collection = store.GetCollection<TestModelWithStringArray>("items");
+        await collection.InsertOneAsync(new TestModelWithStringArray
+        {
+            Id = "1",
+            Type = "test",
+            Fragments = new List<string>()
+        });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Empty arrays should be serialized as []
+        Assert.Contains("[]", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_DoubleFormatting_FivePointZero_WrittenCorrectly()
+    {
+        var path = UTHelpers.GetFullFilePath($"DoubleFmt_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Movie>("movie");
+        await collection.InsertOneAsync(new Movie { Name = "Test", Rating = 5.0 });
+
+        var json = UTHelpers.GetFileContent(path);
+
+        // Newtonsoft writes 5.0, System.Text.Json writes 5 — this test catches the difference
+        Assert.Contains("5.0", json);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task GoldenFile_EnumAsInteger()
+    {
+        var path = UTHelpers.GetFullFilePath($"Golden_Enum_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 1,
+            FamilyName = "Test",
+            Parents = new List<Parent>
+            {
+                new Parent { Id = 1, Name = "P1", Gender = Gender.Male, Age = 30 },
+                new Parent { Id = 2, Name = "P2", Gender = Gender.Female, Age = 28 }
+            },
+            Children = new List<Child>()
+        });
+
+        var json = UTHelpers.GetFileContent(path);
+        var normalized = json.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // Enums should be serialized as integers by default
+        Assert.Contains("\"gender\": 0", normalized);
+        Assert.Contains("\"gender\": 1", normalized);
+
+        // Should NOT be serialized as strings
+        Assert.DoesNotContain("\"Male\"", normalized);
+        Assert.DoesNotContain("\"Female\"", normalized);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+}

--- a/JsonFlatFileDataStore.Test/NullAndEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/NullAndEdgeCaseTests.cs
@@ -1,0 +1,342 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Tests for null handling, empty collections, and edge cases that may differ
+/// between Newtonsoft and System.Text.Json serializers.
+/// </summary>
+public class NullAndEdgeCaseTests
+{
+    [Fact]
+    public async Task NullNestedObject_Typed_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"NullNested_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "NoWork",
+            Age = 25,
+            Location = null,
+            Work = null
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<User>("user");
+        var user = collection2.AsQueryable().First();
+
+        Assert.Equal("NoWork", user.Name);
+        Assert.Null(user.Location);
+        Assert.Null(user.Work);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task NullNestedObject_ThenUpdate_ToNonNull()
+    {
+        var path = UTHelpers.GetFullFilePath($"NullToNon_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "Test",
+            Age = 30,
+            Work = null
+        });
+
+        await collection.UpdateOneAsync(
+            e => e.Id == 1,
+            new { Work = new WorkPlace { Name = "NewCo", Location = "SF" } });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<User>("user");
+        var user = collection2.AsQueryable().First();
+
+        Assert.NotNull(user.Work);
+        Assert.Equal("NewCo", user.Work.Name);
+        Assert.Equal("SF", user.Work.Location);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EmptyCollection_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"EmptyCol_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        // Create collection by inserting then deleting
+        var collection = store.GetCollection<Movie>("movie");
+        await collection.InsertOneAsync(new Movie { Name = "Temp", Rating = 1.0 });
+        await collection.DeleteOneAsync(e => e.Name == "Temp");
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Movie>("movie");
+        Assert.Equal(0, collection2.Count);
+
+        // Verify it's detected as a collection (empty array in JSON)
+        var keys = store2.GetKeys(ValueType.Collection);
+        Assert.True(keys.ContainsKey("movie"));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EmptyStringField_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"EmptyStr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "",
+            Age = 0,
+            Location = "",
+            Work = new WorkPlace { Name = "", Location = "" }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<User>("user");
+        var user = collection2.AsQueryable().First();
+
+        Assert.Equal("", user.Name);
+        Assert.Equal("", user.Location);
+        Assert.Equal("", user.Work.Name);
+        Assert.Equal(0, user.Age);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task NullListProperty_Typed_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"NullList_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 1,
+            FamilyName = "NullLists",
+            Parents = null,
+            Children = null,
+            Address = null,
+            BankAccount = null
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Family>("family");
+        var family = collection2.AsQueryable().First();
+
+        Assert.Equal("NullLists", family.FamilyName);
+        Assert.Null(family.Parents);
+        Assert.Null(family.Children);
+        Assert.Null(family.Address);
+        Assert.Null(family.BankAccount);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EmptyListProperty_Typed_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"EmptyList_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 1,
+            FamilyName = "EmptyLists",
+            Parents = new List<Parent>(),
+            Children = new List<Child>()
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Family>("family");
+        var family = collection2.AsQueryable().First();
+
+        Assert.NotNull(family.Parents);
+        Assert.Empty(family.Parents);
+        Assert.NotNull(family.Children);
+        Assert.Empty(family.Children);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DeeplyNestedObject_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DeepNest_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 1,
+            FamilyName = "DeepFamily",
+            Parents = new List<Parent>
+            {
+                new Parent
+                {
+                    Id = 1,
+                    Name = "Parent1",
+                    Gender = Gender.Female,
+                    Age = 35,
+                    Email = "p@test.com",
+                    Phone = "123",
+                    Work = new Work { CompanyName = "BigCorp", Address = "100 Main St" },
+                    FavouriteMovie = "Matrix"
+                }
+            },
+            Children = new List<Child>
+            {
+                new Child
+                {
+                    Name = "Kid1",
+                    Gender = Gender.Male,
+                    Age = 8,
+                    Friends = new List<Friend>
+                    {
+                        new Friend { Name = "Buddy1", Age = 9 },
+                        new Friend { Name = "Buddy2", Age = 7 }
+                    }
+                }
+            },
+            Address = new Address
+            {
+                Street = "456 Oak Ave",
+                PostNumber = 12345,
+                City = "Springfield",
+                Age = 50,
+                Country = new Country { Name = "USA", Code = 1 }
+            },
+            BankAccount = new BankAccount
+            {
+                Opened = new DateTime(2020, 1, 1),
+                Balance = "5000.50",
+                Active = true
+            },
+            Notes = "Some notes"
+        });
+
+        store.Dispose();
+
+        // Verify entire deeply nested structure survives round-trip
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Family>("family");
+        var family = collection2.AsQueryable().First();
+
+        Assert.Equal("DeepFamily", family.FamilyName);
+        Assert.Equal("Parent1", family.Parents[0].Name);
+        Assert.Equal(Gender.Female, family.Parents[0].Gender);
+        Assert.Equal("BigCorp", family.Parents[0].Work.CompanyName);
+        Assert.Equal("Matrix", family.Parents[0].FavouriteMovie);
+        Assert.Equal("Kid1", family.Children[0].Name);
+        Assert.Equal(2, family.Children[0].Friends.Count);
+        Assert.Equal("Buddy1", family.Children[0].Friends[0].Name);
+        Assert.Equal(9, family.Children[0].Friends[0].Age);
+        Assert.Equal("456 Oak Ave", family.Address.Street);
+        Assert.Equal("USA", family.Address.Country.Name);
+        Assert.Equal(1, family.Address.Country.Code);
+        Assert.True(family.BankAccount.Active);
+        Assert.Equal("5000.50", family.BankAccount.Balance);
+        Assert.Equal("Some notes", family.Notes);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DeeplyNestedObject_Dynamic_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DeepDyn_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("complex");
+        await collection.InsertOneAsync(new
+        {
+            id = 1,
+            level1 = new
+            {
+                level2 = new
+                {
+                    level3 = new
+                    {
+                        value = "deep"
+                    }
+                }
+            }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("complex");
+        var item = collection2.AsQueryable().First();
+
+        Assert.Equal("deep", (string)item.level1.level2.level3.value);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task NestedArrays_Typed_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"NestedArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<TestModelWithNestedArray>("items");
+        await collection.InsertOneAsync(new TestModelWithNestedArray
+        {
+            Id = "1",
+            Type = "matrix",
+            NestedLists = new List<List<int>>
+            {
+                new List<int> { 1, 2, 3 },
+                new List<int> { 4, 5, 6 },
+                new List<int> { 7, 8, 9 }
+            }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<TestModelWithNestedArray>("items");
+        var item = collection2.AsQueryable().First();
+
+        Assert.Equal(3, item.NestedLists.Count);
+        Assert.Equal(new List<int> { 1, 2, 3 }, item.NestedLists[0]);
+        Assert.Equal(new List<int> { 4, 5, 6 }, item.NestedLists[1]);
+        Assert.Equal(new List<int> { 7, 8, 9 }, item.NestedLists[2]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+}

--- a/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
+++ b/JsonFlatFileDataStore.Test/NumericEdgeCaseTests.cs
@@ -1,0 +1,277 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Numeric edge cases that commonly differ between Newtonsoft and System.Text.Json:
+/// decimal precision, long boundaries, integers beyond double precision, and special floats.
+/// These tests pin current Newtonsoft behavior.
+/// </summary>
+public class NumericEdgeCaseTests
+{
+    public class DecimalModel
+    {
+        public int Id { get; set; }
+        public decimal Price { get; set; }
+        public decimal? OptionalAmount { get; set; }
+    }
+
+    [Fact]
+    public async Task Decimal_RoundTrip_PreservesPrecision()
+    {
+        var path = UTHelpers.GetFullFilePath($"DecRT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<DecimalModel>("decModel");
+        await collection.InsertOneAsync(new DecimalModel { Id = 1, Price = 19.95m, OptionalAmount = 0.0000001m });
+        await collection.InsertOneAsync(new DecimalModel { Id = 2, Price = 9999999999.99m, OptionalAmount = null });
+        // Note: very large decimals lose precision on the current Newtonsoft path because
+        // the serializer routes data through ExpandoObject (JSON number → double → back).
+        // decimal.MaxValue specifically also fails to deserialize. Use a value within
+        // double precision range to assert lossless round-trip.
+        await collection.InsertOneAsync(new DecimalModel { Id = 3, Price = -0.01m, OptionalAmount = 12345678.99m });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var items = store2.GetCollection<DecimalModel>("decModel").AsQueryable().OrderBy(e => e.Id).ToList();
+
+        Assert.Equal(19.95m, items[0].Price);
+        Assert.Equal(0.0000001m, items[0].OptionalAmount);
+        Assert.Equal(9999999999.99m, items[1].Price);
+        Assert.Null(items[1].OptionalAmount);
+        Assert.Equal(-0.01m, items[2].Price);
+        Assert.Equal(12345678.99m, items[2].OptionalAmount);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Decimal_LargeValue_LosesPrecision_BehaviorPinned()
+    {
+        // Documented limitation of the current Newtonsoft path: very large decimal values
+        // are serialized via JObject → ExpandoObject (which uses double internally),
+        // so significant digits beyond double precision are lost on round trip.
+        // Migration note: STJ may behave differently here — expected to either round-trip
+        // exactly or fail explicitly. Update this test once the migration lands.
+        var path = UTHelpers.GetFullFilePath($"DecLoss_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<DecimalModel>("decModel");
+        await collection.InsertOneAsync(new DecimalModel { Id = 1, Price = 79228162514264337593543950m });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<DecimalModel>("decModel").AsQueryable().First();
+
+        // Precision is lost — assert the value differs from the input.
+        Assert.NotEqual(79228162514264337593543950m, item.Price);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Decimal_DynamicAccess()
+    {
+        var path = UTHelpers.GetFullFilePath($"DecDyn_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<DecimalModel>("decModel");
+        await collection.InsertOneAsync(new DecimalModel { Id = 1, Price = 42.50m });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var dyn = store2.GetCollection("decModel").AsQueryable().First();
+
+        // Dynamic access to a JSON number that originated as decimal.
+        // Newtonsoft surfaces it as either decimal or double depending on the literal form.
+        var price = (decimal)dyn.price;
+        Assert.Equal(42.50m, price);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Int64_MaxAndMin_RoundTrip_Typed()
+    {
+        var path = UTHelpers.GetFullFilePath($"Int64Typed_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("max", long.MaxValue);
+        store.InsertItem("min", long.MinValue);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        Assert.Equal(long.MaxValue, store2.GetItem<long>("max"));
+        Assert.Equal(long.MinValue, store2.GetItem<long>("min"));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Int64_MaxAndMin_RoundTrip_Dynamic()
+    {
+        var path = UTHelpers.GetFullFilePath($"Int64Dyn_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("max", long.MaxValue);
+        store.InsertItem("min", long.MinValue);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var dynMax = store2.GetItem("max");
+        var dynMin = store2.GetItem("min");
+
+        Assert.Equal(long.MaxValue, (long)dynMax);
+        Assert.Equal(long.MinValue, (long)dynMin);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Int64_BeyondDoublePrecision_RoundTrip()
+    {
+        // 2^53 + 1 — first integer that loses precision when stored as double.
+        const long beyondDoublePrecision = 9007199254740993L;
+
+        var path = UTHelpers.GetFullFilePath($"Int64Beyond_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("items");
+        await collection.InsertOneAsync(new { id = 1, big = beyondDoublePrecision });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection("items").AsQueryable().First();
+
+        // Newtonsoft preserves Int64 in dynamic/ExpandoObject, so exact equality holds.
+        long big = item.big;
+        Assert.Equal(beyondDoublePrecision, big);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Double_NaN_RoundTrip_BehaviorPinned()
+    {
+        var path = UTHelpers.GetFullFilePath($"NaN_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("nan", double.NaN);
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var value = store2.GetItem<double>("nan");
+
+        Assert.True(double.IsNaN(value));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Double_Infinity_RoundTrip_BehaviorPinned()
+    {
+        var path = UTHelpers.GetFullFilePath($"Inf_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("posInf", double.PositiveInfinity);
+        store.InsertItem("negInf", double.NegativeInfinity);
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var pos = store2.GetItem<double>("posInf");
+        var neg = store2.GetItem<double>("negInf");
+
+        Assert.True(double.IsPositiveInfinity(pos));
+        Assert.True(double.IsNegativeInfinity(neg));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Int32_MaxAndMin_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"Int32_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("maxInt", int.MaxValue);
+        store.InsertItem("minInt", int.MinValue);
+        store.InsertItem("zero", 0);
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        Assert.Equal(int.MaxValue, store2.GetItem<int>("maxInt"));
+        Assert.Equal(int.MinValue, store2.GetItem<int>("minInt"));
+        Assert.Equal(0, store2.GetItem<int>("zero"));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Double_RoundTrip_PreservesPrecision()
+    {
+        var path = UTHelpers.GetFullFilePath($"DoubleRT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Movie>("movie");
+        await collection.InsertOneAsync(new Movie { Name = "Test Movie", Rating = 7.123456789 });
+        await collection.InsertOneAsync(new Movie { Name = "Exact Five", Rating = 5.0 });
+        await collection.InsertOneAsync(new Movie { Name = "Zero Point One", Rating = 0.1 });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Movie>("movie");
+        var movies = collection2.AsQueryable().ToList();
+
+        Assert.Equal(7.123456789, movies.First(m => m.Name == "Test Movie").Rating);
+        Assert.Equal(5.0, movies.First(m => m.Name == "Exact Five").Rating);
+        Assert.Equal(0.1, movies.First(m => m.Name == "Zero Point One").Rating);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task FloatArray_RoundTrip_PreservesPrecision()
+    {
+        var path = UTHelpers.GetFullFilePath($"FloatArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<World>("world");
+        await collection.InsertOneAsync(new World
+        {
+            Id = 1,
+            Position = new float[] { 1.5f, 2.75f, -3.125f },
+            CameraRotationX = 45.5f,
+            CameraRotationY = -90.25f
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<World>("world");
+        var world = collection2.AsQueryable().First();
+
+        Assert.Equal(1.5f, world.Position[0]);
+        Assert.Equal(2.75f, world.Position[1]);
+        Assert.Equal(-3.125f, world.Position[2]);
+        Assert.Equal(45.5f, world.CameraRotationX);
+        Assert.Equal(-90.25f, world.CameraRotationY);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
+++ b/JsonFlatFileDataStore.Test/SchemaFlexibilityTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+using Newtonsoft.Json;
+
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Pin behavior for: extra JSON properties not on the typed model, malformed input
+/// to UpdateAll, and Reload after an external file write. These are areas where
+/// Newtonsoft and System.Text.Json defaults differ in subtle ways.
+/// </summary>
+public class SchemaFlexibilityTests
+{
+    public class MinimalUser
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public void TypedRead_FileHasExtraFields_BehaviorPinned()
+    {
+        var path = UTHelpers.GetFullFilePath($"Extra_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path,
+            "{ \"user\": [ { \"id\": 1, \"name\": \"Alice\", \"extra\": \"ignored\", \"meta\": { \"a\": 1 } } ] }");
+
+        var store = new DataStore(path);
+        var collection = store.GetCollection<MinimalUser>("user");
+        var user = collection.AsQueryable().First();
+
+        // Typed read drops unknown fields silently — both Newtonsoft and STJ default to this.
+        Assert.Equal(1, user.Id);
+        Assert.Equal("Alice", user.Name);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task TypedUpdate_PreservesExtraFieldsInFile()
+    {
+        // When the model is typed but the on-disk JSON has extra fields, the current behavior is:
+        // updates serialize through the typed model, so extra fields can be lost.
+        // This test pins the *current* outcome — important because STJ may behave differently.
+        var path = UTHelpers.GetFullFilePath($"ExtraUpd_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path,
+            "{ \"user\": [ { \"id\": 1, \"name\": \"Alice\", \"extra\": \"keep\" } ] }");
+
+        var store = new DataStore(path);
+        var collection = store.GetCollection<MinimalUser>("user");
+
+        await collection.UpdateOneAsync(e => e.Id == 1, new { Name = "Bob" });
+
+        store.Dispose();
+
+        var raw = File.ReadAllText(path);
+
+        // Pin the current behavior — adjust the assertion if migration intentionally changes this.
+        // Today (Newtonsoft path): the extra field is dropped because the collection write
+        // serializes the typed list back to JSON, which has no slot for "extra".
+        Assert.DoesNotContain("\"extra\"", raw);
+        Assert.Contains("Bob", raw);
+
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void UpdateAll_InvalidJson_Throws()
+    {
+        var path = UTHelpers.GetFullFilePath($"BadJson_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        Assert.ThrowsAny<JsonException>(() => store.UpdateAll("not valid json {{{"));
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Reload_AfterExternalFileWrite_PicksUpChanges()
+    {
+        var path = UTHelpers.GetFullFilePath($"ExtReload_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path, "{ \"user\": [ { \"id\": 1, \"name\": \"Before\" } ] }");
+
+        var store = new DataStore(path);
+        var initial = store.GetCollection("user").AsQueryable().First();
+        Assert.Equal("Before", (string)initial.name);
+
+        // Simulate an external process modifying the file.
+        File.WriteAllText(path, "{ \"user\": [ { \"id\": 1, \"name\": \"After\" }, { \"id\": 2, \"name\": \"Added\" } ] }");
+
+        store.Reload();
+
+        var after = store.GetCollection("user");
+        Assert.Equal(2, after.Count);
+        var first = after.AsQueryable().First(u => u.id == 1);
+        Assert.Equal("After", (string)first.name);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
+++ b/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
@@ -1,0 +1,338 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Tests that validate serialization/deserialization behavior critical for
+/// ensuring parity when switching JSON serializers (e.g., Newtonsoft → System.Text.Json).
+/// </summary>
+public class SerializationRoundTripTests
+{
+    [Fact]
+    public void DynamicNumberTypes_IntegerPreservedAfterRoundTrip()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("user");
+        var firstUser = collection.AsQueryable().First();
+
+        // Newtonsoft deserializes JSON integers as Int64 in dynamic/ExpandoObject mode.
+        // System.Text.Json returns JsonElement instead — must ensure numeric types remain usable.
+        long id = firstUser.id;
+        long age = firstUser.age;
+        Assert.Equal(1L, id);
+        Assert.Equal(40L, age);
+
+        // Verify arithmetic works on dynamic numeric values
+        Assert.Equal(2L, id + 1);
+        Assert.Equal(41L, age + 1);
+
+        // Verify the underlying type is Int64, not JsonElement or other wrapper
+        Assert.IsType<long>(firstUser.id);
+        Assert.IsType<long>(firstUser.age);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void DynamicNumberTypes_IntegerPreservedAfterFileReload()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynNumReload_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("items");
+        collection.InsertOne(new { id = 1, count = 42, score = 99 });
+        store.Dispose();
+
+        // Reload from file in a new DataStore instance
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("items");
+        var item = collection2.AsQueryable().First();
+
+        // Newtonsoft returns Int64 for dynamic integer fields
+        long id = item.id;
+        long count = item.count;
+        long score = item.score;
+        Assert.Equal(1L, id);
+        Assert.Equal(42L, count);
+        Assert.Equal(99L, score);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void DynamicNestedObject_PreservedAsExpandoObject()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("user");
+        var user = collection.AsQueryable().First();
+
+        // Nested object should be accessible as dynamic, not as a raw JSON token
+        Assert.NotNull(user.work);
+        string workName = user.work.name;
+        string workLocation = user.work.location;
+        Assert.Equal("ACME", workName);
+        Assert.Equal("NY", workLocation);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public async Task DynamicNestedObject_RoundTrip_AfterInsertAndReload()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynNested_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("people");
+        await collection.InsertOneAsync(new
+        {
+            id = 1,
+            name = "Alice",
+            address = new
+            {
+                street = "123 Main St",
+                city = "Springfield",
+                zip = 62704
+            }
+        });
+
+        store.Dispose();
+
+        // Reload and verify nested structure
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("people");
+        var person = collection2.AsQueryable().First();
+
+        Assert.Equal("Alice", (string)person.name);
+        Assert.Equal("123 Main St", (string)person.address.street);
+        Assert.Equal("Springfield", (string)person.address.city);
+        long zip = person.address.zip;
+        Assert.Equal(62704L, zip);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DynamicMixedTypes_AllTypesPreservedAfterRoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynMixed_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("data");
+        await collection.InsertOneAsync(new
+        {
+            id = 1,
+            stringVal = "hello",
+            intVal = 42,
+            doubleVal = 3.14,
+            boolVal = true,
+            nullVal = (string)null
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("data");
+        var item = collection2.AsQueryable().First();
+
+        Assert.Equal("hello", (string)item.stringVal);
+        Assert.Equal(42, (int)(long)item.intVal);
+        Assert.Equal(3.14, (double)item.doubleVal);
+        Assert.True((bool)item.boolVal);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task TypedEnum_RoundTrip_PreservesValue()
+    {
+        var path = UTHelpers.GetFullFilePath($"EnumRT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 100,
+            FamilyName = "TestFamily",
+            Parents = new List<Parent>
+            {
+                new Parent { Id = 1, Name = "Dad", Gender = Gender.Male, Age = 35 },
+                new Parent { Id = 2, Name = "Mom", Gender = Gender.Female, Age = 33 }
+            },
+            Children = new List<Child>()
+        });
+
+        store.Dispose();
+
+        // Reload and verify enum values
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Family>("family");
+        var family = collection2.AsQueryable().First(f => f.Id == 100);
+
+        Assert.Equal(Gender.Male, family.Parents[0].Gender);
+        Assert.Equal(Gender.Female, family.Parents[1].Gender);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DynamicArrayField_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DynArr_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("tags", new List<string> { "alpha", "beta", "gamma" });
+        store.InsertItem("numbers", new List<int> { 10, 20, 30 });
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+
+        var tags = store2.GetItem<List<string>>("tags");
+        Assert.Equal(3, tags.Count);
+        Assert.Equal("alpha", tags[0]);
+        Assert.Equal("beta", tags[1]);
+        Assert.Equal("gamma", tags[2]);
+
+        var numbers = store2.GetItem<List<int>>("numbers");
+        Assert.Equal(3, numbers.Count);
+        Assert.Equal(10, numbers[0]);
+        Assert.Equal(20, numbers[1]);
+        Assert.Equal(30, numbers[2]);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task AnonymousType_InsertAndRead_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"AnonRT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection("things");
+        collection.InsertOne(new { id = 1, label = "Widget", quantity = 5, active = true });
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("things");
+        var item = collection2.AsQueryable().First();
+
+        Assert.Equal(1, (int)(long)item.id);
+        Assert.Equal("Widget", (string)item.label);
+        Assert.Equal(5, (int)(long)item.quantity);
+        Assert.True((bool)item.active);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task BooleanValue_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"BoolRT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("flag", true);
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var flag = store2.GetItem<bool>("flag");
+        Assert.True(flag);
+
+        var dynamicFlag = store2.GetItem("flag");
+        Assert.True((bool)dynamicFlag);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task StringEscaping_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"Escape_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true);
+
+        var collection = store.GetCollection("items");
+        await collection.InsertOneAsync(new { id = 1, text = "He said \"hello\"" });
+        await collection.InsertOneAsync(new { id = 2, text = "path\\to\\file" });
+        await collection.InsertOneAsync(new { id = 3, text = "line1\nline2" });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("items");
+        var items = collection2.AsQueryable().ToList();
+
+        Assert.Equal("He said \"hello\"", (string)items[0].text);
+        Assert.Equal("path\\to\\file", (string)items[1].text);
+        Assert.Equal("line1\nline2", (string)items[2].text);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task UnicodeStrings_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"Unicode_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, useLowerCamelCase: true);
+
+        var collection = store.GetCollection("items");
+        await collection.InsertOneAsync(new { id = 1, text = "日本語テスト" });
+        await collection.InsertOneAsync(new { id = 2, text = "émojis: 🎉" });
+        await collection.InsertOneAsync(new { id = 3, text = "Ñoño" });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection("items");
+        var items = collection2.AsQueryable().ToList();
+
+        Assert.Equal("日本語テスト", (string)items[0].text);
+        Assert.Equal("émojis: 🎉", (string)items[1].text);
+        Assert.Equal("Ñoño", (string)items[2].text);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task EncryptedCollection_RoundTrip_PreservesData()
+    {
+        const string encryptionKey = "t3stK3y139";
+        var path = UTHelpers.GetFullFilePath($"EncColl_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path, encryptionKey: encryptionKey);
+
+        var collection = store.GetCollection<User>("user");
+        await collection.InsertOneAsync(new User
+        {
+            Id = 1,
+            Name = "Secret",
+            Age = 42,
+            Work = new WorkPlace { Name = "Vault", Location = "Underground" }
+        });
+
+        store.Dispose();
+
+        // File on disk must not contain plaintext
+        var raw = UTHelpers.GetFileContent(path);
+        Assert.DoesNotContain("Secret", raw);
+
+        // Reload with key — data must survive round-trip
+        var store2 = new DataStore(path, encryptionKey: encryptionKey);
+        var collection2 = store2.GetCollection<User>("user");
+        var user = collection2.AsQueryable().First();
+
+        Assert.Equal("Secret", user.Name);
+        Assert.Equal(42, user.Age);
+        Assert.Equal("Vault", user.Work.Name);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
+++ b/JsonFlatFileDataStore.Test/SerializationRoundTripTests.cs
@@ -266,11 +266,11 @@ public class SerializationRoundTripTests
 
         var store2 = new DataStore(path);
         var collection2 = store2.GetCollection("items");
-        var items = collection2.AsQueryable().ToList();
+        var texts = collection2.AsQueryable().Select(x => (string)x.text).ToList();
 
-        Assert.Equal("He said \"hello\"", (string)items[0].text);
-        Assert.Equal("path\\to\\file", (string)items[1].text);
-        Assert.Equal("line1\nline2", (string)items[2].text);
+        Assert.Contains("He said \"hello\"", texts);
+        Assert.Contains("path\\to\\file", texts);
+        Assert.Contains("line1\nline2", texts);
 
         store2.Dispose();
         UTHelpers.Down(path);
@@ -291,11 +291,11 @@ public class SerializationRoundTripTests
 
         var store2 = new DataStore(path);
         var collection2 = store2.GetCollection("items");
-        var items = collection2.AsQueryable().ToList();
+        var texts = collection2.AsQueryable().Select(x => (string)x.text).ToList();
 
-        Assert.Equal("日本語テスト", (string)items[0].text);
-        Assert.Equal("émojis: 🎉", (string)items[1].text);
-        Assert.Equal("Ñoño", (string)items[2].text);
+        Assert.Contains("日本語テスト", texts);
+        Assert.Contains("émojis: 🎉", texts);
+        Assert.Contains("Ñoño", texts);
 
         store2.Dispose();
         UTHelpers.Down(path);

--- a/JsonFlatFileDataStore.Test/SingleItemTests.cs
+++ b/JsonFlatFileDataStore.Test/SingleItemTests.cs
@@ -379,6 +379,70 @@ public class SingleItemTests
         UTHelpers.Down(newFilePath);
     }
 
+    [Fact]
+    public void UpdateItem_Sync_TypedUser()
+    {
+        var (newFilePath, store) = InitializeFileAndStore();
+
+        var result = store.InsertItem("myUser2", new User { Id = 12, Name = "Teddy" });
+        Assert.True(result);
+
+        var updated = store.UpdateItem("myUser2", new { name = "Harold" });
+        Assert.True(updated);
+
+        var user = store.GetItem<User>("myUser2");
+        Assert.Equal("Harold", user.Name);
+
+        var store2 = CreateStore(newFilePath);
+        var user2 = store2.GetItem<User>("myUser2");
+        Assert.Equal("Harold", user2.Name);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void UpdateItem_Sync_DynamicUser()
+    {
+        var (newFilePath, store) = InitializeFileAndStore();
+
+        store.InsertItem("myUser2", new { id = 12, name = "Teddy", age = 30 });
+
+        var updated = store.UpdateItem("myUser2", new { name = "Harold" });
+        Assert.True(updated);
+
+        var user = store.GetItem("myUser2");
+        Assert.Equal("Harold", user.name);
+        Assert.Equal(30, (int)user.age);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void UpdateItem_Sync_KeyNotFound_ReturnsFalse()
+    {
+        var (newFilePath, store) = InitializeFileAndStore();
+
+        var result = store.UpdateItem("nonExistentKey", new { name = "Nobody" });
+        Assert.False(result);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void UpdateItem_Sync_ValueType()
+    {
+        var (newFilePath, store) = InitializeFileAndStore();
+
+        store.InsertItem("counter", 10);
+        var updated = store.UpdateItem("counter", 99);
+        Assert.True(updated);
+
+        var value = store.GetItem<int>("counter");
+        Assert.Equal(99, value);
+
+        UTHelpers.Down(newFilePath);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData(EncryptionPassword)]
@@ -407,5 +471,23 @@ public class SingleItemTests
         Assert.Null(user);
 
         UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void SingleItem_StringValue_InsertReplace()
+    {
+        var path = UTHelpers.GetFullFilePath($"StringItem_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        store.InsertItem("greeting", "hello");
+        var val = store.GetItem<string>("greeting");
+        Assert.Equal("hello", val);
+
+        store.ReplaceItem("greeting", "world");
+        var val2 = store.GetItem<string>("greeting");
+        Assert.Equal("world", val2);
+
+        store.Dispose();
+        UTHelpers.Down(path);
     }
 }

--- a/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
+++ b/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
@@ -1,0 +1,231 @@
+namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Round-trip tests for temporal types (DateTimeOffset, TimeSpan, DateTime.Kind)
+/// and identifier types (Guid). These have known representational differences
+/// between Newtonsoft and System.Text.Json — pin current Newtonsoft behavior.
+/// </summary>
+public class TemporalAndIdentifierTests
+{
+    public class TemporalModel
+    {
+        public int Id { get; set; }
+        public DateTimeOffset Offset { get; set; }
+        public TimeSpan Duration { get; set; }
+        public DateTime Stamp { get; set; }
+    }
+
+    public class GuidModel
+    {
+        public int Id { get; set; }
+        public Guid Token { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public async Task DateTimeOffset_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DTO_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var original = new DateTimeOffset(2024, 6, 15, 14, 30, 45, TimeSpan.FromHours(3));
+
+        var collection = store.GetCollection<TemporalModel>("temporal");
+        await collection.InsertOneAsync(new TemporalModel
+        {
+            Id = 1,
+            Offset = original,
+            Duration = TimeSpan.Zero,
+            Stamp = DateTime.UtcNow
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<TemporalModel>("temporal").AsQueryable().First();
+
+        Assert.Equal(original, item.Offset);
+        Assert.Equal(original.UtcDateTime, item.Offset.UtcDateTime);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task TimeSpan_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"TS_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var duration = TimeSpan.FromMinutes(90).Add(TimeSpan.FromMilliseconds(123));
+
+        var collection = store.GetCollection<TemporalModel>("temporal");
+        await collection.InsertOneAsync(new TemporalModel
+        {
+            Id = 1,
+            Offset = DateTimeOffset.UtcNow,
+            Duration = duration,
+            Stamp = DateTime.UtcNow
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<TemporalModel>("temporal").AsQueryable().First();
+
+        Assert.Equal(duration, item.Duration);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task Guid_Typed_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"GuidT_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var token = Guid.NewGuid();
+
+        var collection = store.GetCollection<GuidModel>("guidModel");
+        await collection.InsertOneAsync(new GuidModel { Id = 1, Token = token, Name = "G" });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var item = store2.GetCollection<GuidModel>("guidModel").AsQueryable().First();
+
+        Assert.Equal(token, item.Token);
+        Assert.Equal("G", item.Name);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void Guid_AsIdField_NotSupported_BehaviorPinned()
+    {
+        // Documented limitation: a typed model with a Guid as the key property fails on insert
+        // because the library's dynamic-dispatch path through ObjectExtensions.AddDataToField
+        // cannot set a Guid value via reflection in this code path.
+        //
+        // Migration note: STJ may or may not surface this same failure. If it does not,
+        // update this test to assert success.
+        var path = UTHelpers.GetFullFilePath($"GuidIdLim_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIdModel");
+
+        Assert.Throws<ArgumentException>(() =>
+            collection.InsertOne(new GuidIdModel { Id = Guid.NewGuid(), Name = "X" }));
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    public class GuidIdModel
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public void Guid_SingleItem_TypedRoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"GuidItem_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var guid = Guid.NewGuid();
+        store.InsertItem("token", guid);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        Assert.Equal(guid, store2.GetItem<Guid>("token"));
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void DateTime_UtcKind_PreservedAfterRoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DTUtc_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var utc = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        store.InsertItem("when", utc);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var read = store2.GetItem<DateTime>("when");
+
+        Assert.Equal(DateTimeKind.Utc, read.Kind);
+        Assert.Equal(utc, read);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public async Task DateTime_InTypedModel_RoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DateTimeModel_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var testDate = new DateTime(2023, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var collection = store.GetCollection<Family>("family");
+        await collection.InsertOneAsync(new Family
+        {
+            Id = 1,
+            FamilyName = "TestFamily",
+            Parents = new List<Parent>(),
+            Children = new List<Child>(),
+            BankAccount = new BankAccount
+            {
+                Opened = testDate,
+                Balance = "1000.00",
+                Active = true
+            }
+        });
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var collection2 = store2.GetCollection<Family>("family");
+        var family = collection2.AsQueryable().First();
+
+        Assert.Equal(testDate.Year, family.BankAccount.Opened.Year);
+        Assert.Equal(testDate.Month, family.BankAccount.Opened.Month);
+        Assert.Equal(testDate.Day, family.BankAccount.Opened.Day);
+        Assert.True(family.BankAccount.Active);
+        Assert.Equal("1000.00", family.BankAccount.Balance);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void DateTime_LocalKind_PreservedAfterRoundTrip()
+    {
+        var path = UTHelpers.GetFullFilePath($"DTLocal_{DateTime.UtcNow.Ticks}");
+        var store = new DataStore(path);
+
+        var local = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Local);
+        store.InsertItem("when", local);
+
+        store.Dispose();
+
+        var store2 = new DataStore(path);
+        var read = store2.GetItem<DateTime>("when");
+
+        // Newtonsoft default DateTimeZoneHandling = RoundtripKind preserves Local.
+        Assert.Equal(DateTimeKind.Local, read.Kind);
+        Assert.Equal(local, read);
+
+        store2.Dispose();
+        UTHelpers.Down(path);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ await store.InsertItemAsync("counter", 1);
 var counter = await store.GetItem<int>("counter");
 ```
 
+> **Note:** A typed collection reads JSON into instances of the typed model, so any
+> properties present in the JSON file but missing from the model are dropped on the
+> next write. Don't mix typed and dynamic access against the same collection if the
+> dynamic side adds fields the typed model doesn't declare — those fields will be
+> lost the next time the typed collection is saved. Use a dynamic collection
+> (`GetCollection(string)`) when the schema is open.
+
 ### Dynamically Typed Data
 
 Dynamic data can be any of the following types:
@@ -423,6 +430,12 @@ await collection.DeleteManyAsync(e => e.City == "NY");
 
 If incrementing Id-field values are used, `GetNextIdValue` returns the next Id-field value. For integer Id-properties, the last item's value is incremented by one. For non-integer fields, the value is converted to a string and number at the end of the sting is parsed and incremented by one.
 
+> **Supported Id-field types:** integer types and `string` work as the collection key.
+> `Guid` is **not** supported as the Id property of a typed collection — inserts throw
+> at runtime. Use `int` or `string` as the key and keep the `Guid` in another field if
+> you need one per row. `Guid` is fine everywhere else (non-key fields,
+> `InsertItem`/`GetItem<Guid>` for single items).
+
 ```csharp
 var store = new DataStore(newFilePath, keyProperty: "myId");
 
@@ -670,6 +683,14 @@ collection2.ReplaceOne(e => e.id == 11, dynamicUser as object);
 // Compiler will also accept this
 collection2.ReplaceOne((Predicate<dynamic>)(e => e.id == 11), dynamicUser);
 ```
+
+## Known Limitations
+
+### Decimal precision
+
+Large `decimal` values do not survive a round trip cleanly. Data is internally routed through `ExpandoObject`, which represents JSON numbers as `double`, so anything past roughly 15 significant digits becomes inexact. `decimal.MaxValue` is a worst case — it is written in scientific notation (`7.922816251426434E+28`) that cannot be parsed back as `decimal` at all, and reading the file raises `JsonReaderException`.
+
+If you need exact preservation of large or high-precision decimals, store them as strings. Pinned by `NumericEdgeCaseTests`.
 
 ## C# Language Version
 


### PR DESCRIPTION
  Adds new test files covering serialization round-trips, dictionary key/value
  handling, JToken inputs, numeric and null edge cases, case sensitivity,
  schema flexibility, dynamic access, file access, JSON output formatting,
  temporal/identifier handling, and golden-master behavior pinning. Extends
  existing CollectionInsertBatch, CollectionModification, CollectionQuery, and
  SingleItem test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extensive new test suites pinning serialization/formatting, case-sensitivity, concurrent inserts, replace/update semantics, dynamic/Expando behaviors, dictionary key round-trips, JToken inputs, file read/write transforms, numeric/temporal edge cases, schema flexibility, null/nested-edge cases, and single-item operations.

* **Documentation**
  * README updated with warnings about mixing typed vs dynamic access, Guid-as-key limitation, and known decimal precision/round-trip limitations (suggest storing high-precision decimals as strings).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ttu/json-flatfile-datastore/pull/118)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->