### PR TITLE
fix: retry JSON parse on read to tolerate concurrent partial-file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### [Unreleased]
 * FIXED: Update functionality when objects has collections with nested collections
+* FIXED: Retry JSON parse on read to tolerate concurrent partial-file writes
 
 ### [2.4.2] - 2023-06-25
 * FIXED: Duplicate collection data to JSON on save when configured case was not used with collection name

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -433,7 +433,27 @@ public class DataStore : IDataStore
 
     private string GetJsonTextFromFile() => FileAccess.ReadJsonFromFile(_filePath, _encryptJson, _decryptJson);
 
-    private JObject GetJsonObjectFromFile() => JObject.Parse(GetJsonTextFromFile());
+    private JObject GetJsonObjectFromFile()
+    {
+        // The writer is non-atomic (File.WriteAllText truncates then writes), so a concurrent
+        // reader can observe a partially-written file and JObject.Parse will throw. Retry briefly —
+        // the writer finishes in milliseconds. Cannot use a temp-file-then-rename strategy because
+        // users may have permission for the data file only.
+        const int maxAttempts = 50;
+        const int delayMs = 20;
+        for (var attempt = 0; ; attempt++)
+        {
+            var jsonText = GetJsonTextFromFile();
+            try
+            {
+                return JObject.Parse(jsonText);
+            }
+            catch (JsonReaderException) when (attempt < maxAttempts - 1)
+            {
+                Thread.Sleep(delayMs);
+            }
+        }
+    }
 
     internal class CommitAction
     {


### PR DESCRIPTION
File.WriteAllText truncates then writes non-atomically, so a concurrent reader can observe a partially-written file and JObject.Parse throws. Retry briefly (50 × 20ms), the writer finishes in milliseconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON data reading now includes automatic retry logic to handle transient parsing failures, improving reliability when accessing data files with timing-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ttu/json-flatfile-datastore/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->