### PR TITLE
fix: drain commit batch when an action throws to avoid InnerCommit hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### [Unreleased]
 * FIXED: Update functionality when objects has collections with nested collections
+* FIXED: A failing commit action no longer hangs other callers in the same batch
 
 ### [2.4.2] - 2023-06-25
 * FIXED: Duplicate collection data to JSON on save when configured case was not used with collection name

--- a/JsonFlatFileDataStore/CommitActionHandler.cs
+++ b/JsonFlatFileDataStore/CommitActionHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using Newtonsoft.Json.Linq;
@@ -40,26 +41,40 @@ internal static class CommitActionHandler
 
             var jsonText = getLatestJson();
 
+            Exception actionException = null;
+
             foreach (var action in batch)
             {
-                var (actionSuccess, updatedJson) = action.HandleAction(JObject.Parse(jsonText));
+                try
+                {
+                    var (actionSuccess, updatedJson) = action.HandleAction(JObject.Parse(jsonText));
 
-                callbacks.Enqueue((action, actionSuccess));
+                    callbacks.Enqueue((action, actionSuccess));
 
-                if (actionSuccess)
-                    jsonText = updatedJson;
+                    if (actionSuccess)
+                        jsonText = updatedJson;
+                }
+                catch (Exception e)
+                {
+                    // Record the failure but keep draining the batch so every caller's Ready
+                    // callback fires — otherwise InnerCommit's wait loop would hang forever.
+                    actionException = e;
+                    callbacks.Enqueue((action, false));
+                }
             }
 
             var updateSuccess = false;
-            Exception actionException = null;
 
-            try
+            if (actionException == null)
             {
-                updateSuccess = updateState(jsonText);
-            }
-            catch (Exception e)
-            {
-                actionException = e;
+                try
+                {
+                    updateSuccess = updateState(jsonText);
+                }
+                catch (Exception e)
+                {
+                    actionException = e;
+                }
             }
 
             foreach (var (cbAction, cbSuccess) in callbacks)


### PR DESCRIPTION
If a single action's Parse or HandleAction throws, the foreach exited before enqueueing callbacks for the remaining batch members. Their Ready callbacks never fired, hanging InnerCommit's wait loop.

Now per-action failures are caught and recorded; every action gets a callback, and updateState is skipped if any action threw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch commit processing so a failed action no longer prevents other actions in the same batch from completing.
  * Callbacks now receive the appropriate failure when an individual action or state update encounters an error.
  * Added a changelog entry documenting this correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->