### PR TITLE
fix: match collection keys case-insensitively in camelCase mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * FIXED: Update functionality when objects has collections with nested collections
 * FIXED: Retry JSON parse on read to tolerate concurrent partial-file writes
 * FIXED: A failing commit action no longer hangs other callers in the same batch
+* FIXED: Collection key in file not matching configured case is now matched case-insensitively, instead of reading empty and duplicating the key on save
 
 ### [2.4.2] - 2023-06-25
 * FIXED: Duplicate collection data to JSON on save when configured case was not used with collection name

--- a/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
+++ b/JsonFlatFileDataStore.Test/CaseSensitivityTests.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -45,6 +47,55 @@ public class CaseSensitivityTests
         Assert.Equal(40, user.Age);
 
         store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void ReadExistingFile_PascalCaseCollectionKey_IsReadable()
+    {
+        var path = UTHelpers.GetFullFilePath($"PascalKey_{DateTime.UtcNow.Ticks}");
+
+        // The collection KEY itself is Pascal case ("User"), not just the item properties.
+        File.WriteAllText(path, "{ \"User\": [ { \"Id\": 1, \"Name\": \"Alice\", \"Age\": 30 } ] }");
+
+        var store = new DataStore(path, useLowerCamelCase: true);
+        var collection = store.GetCollection<User>("User");
+
+        // In camelCase mode the collection path is looked up as "user"; the store must still find
+        // the "User" key instead of treating the collection as empty.
+        Assert.Equal(1, collection.Count);
+        Assert.Equal("Alice", collection.AsQueryable().First().Name);
+
+        store.Dispose();
+        UTHelpers.Down(path);
+    }
+
+    [Fact]
+    public void InsertInto_PascalCaseCollectionKey_DoesNotDuplicateKey()
+    {
+        var path = UTHelpers.GetFullFilePath($"PascalKeyInsert_{DateTime.UtcNow.Ticks}");
+
+        File.WriteAllText(path, "{ \"User\": [ { \"Id\": 1, \"Name\": \"Alice\" } ] }");
+
+        var store = new DataStore(path, useLowerCamelCase: true);
+        var collection = store.GetCollection<User>("User");
+        collection.InsertOne(new User { Id = 2, Name = "Bob" });
+        store.Dispose();
+
+        // The existing "User" collection must be updated in place, not shadowed by a second
+        // camelCased "user" key. A JSON object with two keys differing only by case is corrupt.
+        var root = JObject.Parse(File.ReadAllText(path));
+        var userKeys = root.Properties()
+                           .Where(p => string.Equals(p.Name, "user", StringComparison.OrdinalIgnoreCase))
+                           .ToList();
+        Assert.Single(userKeys);
+        Assert.Equal(2, userKeys[0].Value.Count());
+
+        // Reopening finds both items through the collection API.
+        var store2 = new DataStore(path, useLowerCamelCase: true);
+        Assert.Equal(2, store2.GetCollection<User>("User").Count);
+        store2.Dispose();
+
         UTHelpers.Down(path);
     }
 

--- a/JsonFlatFileDataStore/DataStore.cs
+++ b/JsonFlatFileDataStore/DataStore.cs
@@ -323,7 +323,10 @@ public class DataStore : IDataStore
                     _jsonData = GetJsonObjectFromFile();
                 }
 
-                return _jsonData[pathWithConfiguredCase]?
+                // Match case-insensitively: in camelCase mode the lookup path is camelCased
+                // (e.g. "user") but a file authored elsewhere may store the key as "User".
+                // A case-sensitive miss would incorrectly read the collection as empty.
+                return _jsonData.Property(pathWithConfiguredCase, StringComparison.OrdinalIgnoreCase)?.Value
                        .Children()
                        .Select(e => readConvert(e))
                        .ToList()
@@ -361,7 +364,11 @@ public class DataStore : IDataStore
         {
             var updatedJson = string.Empty;
 
-            var selectedData = currentJson[dataPath]?
+            // Match case-insensitively so a Pascal-cased key in an externally authored file
+            // ("User") is found by the camelCased lookup path ("user").
+            var existingProperty = currentJson.Property(dataPath, StringComparison.OrdinalIgnoreCase);
+
+            var selectedData = existingProperty?.Value
                                .Children()
                                .Select(e => readConvert(e))
                                .ToList()
@@ -371,7 +378,17 @@ public class DataStore : IDataStore
 
             if (success)
             {
-                currentJson[dataPath] = JArray.FromObject(selectedData);
+                var newArray = JArray.FromObject(selectedData);
+
+                // Update the existing property in place (preserving its key) rather than adding a
+                // second property that differs only by case; _toJsonFunc normalizes the key to
+                // camelCase on write. Setting currentJson[dataPath] directly would leave the
+                // original "User" key alongside a new "user" key, corrupting the document.
+                if (existingProperty != null)
+                    existingProperty.Value = newArray;
+                else
+                    currentJson[dataPath] = newArray;
+
                 updatedJson = _toJsonFunc(currentJson);
             }
 


### PR DESCRIPTION
In camelCase mode (the default) a collection path is camelCased for lookup (e.g. "User" -> "user"), but the JObject indexer is case-sensitive. The 2.4.2 fix (#88) aligned the access path to the library's camelCase convention, which covers collections the library itself created. It does not cover an externally-authored file whose stored key is Pascal case ("User"): the camelCased lookup ("user") still misses, so

- reads (GetCollection<T>) returned the collection as empty, and
- writes (Commit<T>) created a second "user" key next to the original "User"; _toJsonFunc then camelCased both to "user", producing a JSON object with two keys differing only by case. Re-parsing collapses them (last-wins), silently losing every item that existed before the write.

Look the property up case-insensitively in both spots, and on write update the existing property in place instead of adding a new one; _toJsonFunc still normalizes the key to camelCase. This is a superset of the #88 behavior. Pinned by two new CaseSensitivityTests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed collection access when the stored collection key uses different capitalization than configured.
  - Prevented duplicate collections from being created when key casing differs.
  - Preserved existing collection key capitalization when saving updates.
  - Ensured existing data remains readable and updates are written to the correct collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->