### PR TITLE
fix: make full text search of numbers and dates culture-invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * FIXED: Retry JSON parse on read to tolerate concurrent partial-file writes
 * FIXED: A failing commit action no longer hangs other callers in the same batch
 * FIXED: Collection key in file not matching configured case is now matched case-insensitively, instead of reading empty and duplicating the key on save
-* FIXED: Full text search of numeric and date values is now culture-invariant, instead of depending on the machine's locale
+* FIXED: Full-text search of numeric and date values is now culture-invariant, instead of depending on the machine's locale
 
 ### [2.4.2] - 2023-06-25
 * FIXED: Duplicate collection data to JSON on save when configured case was not used with collection name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FIXED: Retry JSON parse on read to tolerate concurrent partial-file writes
 * FIXED: A failing commit action no longer hangs other callers in the same batch
 * FIXED: Collection key in file not matching configured case is now matched case-insensitively, instead of reading empty and duplicating the key on save
+* FIXED: Full text search of numeric and date values is now culture-invariant, instead of depending on the machine's locale
 
 ### [2.4.2] - 2023-06-25
 * FIXED: Duplicate collection data to JSON on save when configured case was not used with collection name

--- a/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Globalization;
+using Newtonsoft.Json.Linq;
 
 namespace JsonFlatFileDataStore.Test;
 
@@ -289,6 +290,35 @@ public class CollectionQueryTests
         Assert.Equal(9, matches3.Count());
 
         UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void FullTextSearch_NumericValue_IsCultureInvariant()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            // A culture whose decimal separator is a comma. Before the fix the stored value was
+            // rendered with ToString() under this culture, so "9,99" matched and "9.99" did not.
+            CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
+
+            var newFilePath = UTHelpers.Up();
+
+            var store = new DataStore(newFilePath);
+
+            var collection = store.GetCollection<Movie>("movie");
+            collection.InsertOne(new Movie { Name = "The Room", Rating = 9.99 });
+
+            Assert.Single(collection.Find("9.99"));
+            Assert.Empty(collection.Find("9,99"));
+
+            UTHelpers.Down(newFilePath);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]

--- a/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
+++ b/JsonFlatFileDataStore.Test/CollectionQueryTests.cs
@@ -305,15 +305,20 @@ public class CollectionQueryTests
 
             var newFilePath = UTHelpers.Up();
 
-            var store = new DataStore(newFilePath);
+            try
+            {
+                var store = new DataStore(newFilePath);
 
-            var collection = store.GetCollection<Movie>("movie");
-            collection.InsertOne(new Movie { Name = "The Room", Rating = 9.99 });
+                var collection = store.GetCollection<Movie>("movie");
+                collection.InsertOne(new Movie { Name = "The Room", Rating = 9.99 });
 
-            Assert.Single(collection.Find("9.99"));
-            Assert.Empty(collection.Find("9,99"));
-
-            UTHelpers.Down(newFilePath);
+                Assert.Single(collection.Find("9.99"));
+                Assert.Empty(collection.Find("9,99"));
+            }
+            finally
+            {
+                UTHelpers.Down(newFilePath);
+            }
         }
         finally
         {

--- a/JsonFlatFileDataStore/ObjectExtensions.cs
+++ b/JsonFlatFileDataStore/ObjectExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -88,7 +89,11 @@ internal static class ObjectExtensions
                 return false;
 
             if (!IsValueReferenceType(current.GetType()))
-                return compareFunc(current.ToString(), text);
+                // Format leaf values (numbers, dates) with the invariant culture so a search is
+                // not affected by the machine's locale — otherwise a decimal stored as 9.99 would
+                // only match "9,99" where the decimal separator is a comma. Matches the invariant
+                // formatting DataStore uses when it reads dynamic values back.
+                return compareFunc(Convert.ToString((object)current, CultureInfo.InvariantCulture), text);
 
             foreach (var srcProp in GetProperties(current))
             {


### PR DESCRIPTION
## Problem

`Find(string)` renders each leaf value with `ToString()` under the ambient culture (`ObjectExtensions.FullTextSearch`), so full-text search over numbers and dates depends on the machine's locale. On a `fi-FI` machine, where the decimal separator is a comma:

```csharp
collection.InsertOne(new Movie { Name = "The Room", Rating = 9.99 });

collection.Find("9.99");   // 0 matches
collection.Find("9,99");   // 1 match
```

The same query works on one server and not another.

## Fix

Format leaf values with `CultureInfo.InvariantCulture`:

```csharp
return compareFunc(Convert.ToString((object)current, CultureInfo.InvariantCulture), text);
```

This matches the invariant formatting `DataStore.SingleDynamicItemReadConverter` already uses when reading dynamic values back. Integer and string searches are unaffected (no separator to localise).

## Tests

`FullTextSearch_NumericValue_IsCultureInvariant` added, written before the fix and watched failing first: it forces `CultureInfo.CurrentCulture` to `fi-FI`, stores `9.99`, and asserts `Find("9.99")` matches while `Find("9,99")` does not, restoring the culture in a `finally`.

Full suite: **239 passed, 0 failed** (238 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn184u1sK2zuFMTc4PNdrR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Full-text search for numeric and date values is now culture-invariant, avoiding mismatches caused by regional settings.
  * Decimal searches now match using invariant formatting (e.g., searching `9.99` no longer depends on locale-specific separators).
* **Tests**
  * Added a regression test covering numeric culture-invariant full-text search behavior under a non-default culture.
* **Documentation**
  * Updated the changelog with the culture-invariant full-text search fix in the Unreleased section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->