### PR TITLE
feat: support Guid as the collection's id-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### [Unreleased]
+* ADDED: Support for `Guid` Id-fields. Values are not incremented: a new `Guid` is generated when the inserted item doesn't have an Id-field value, and a value set by the caller is kept as is
+* CHANGED: When the Id-field is not declared as a `Guid` but the collection's last item has an Id-field value that is a valid `Guid`, the next value is a new `Guid` as a string. Earlier the number at the end of the string was incremented, which returned a valid `Guid` only when the previous value happened to end in a digit, e.g. `..0305e82c330a` returned `..0305e82c330a0` and `Guid.Empty` returned `00000000-0000-0000-0000-1`
 
 
 ### [2.4.3] - 2026-08-22

--- a/JsonFlatFileDataStore.Test/GuidIdFieldTests.cs
+++ b/JsonFlatFileDataStore.Test/GuidIdFieldTests.cs
@@ -1,0 +1,371 @@
+﻿namespace JsonFlatFileDataStore.Test;
+
+/// <summary>
+/// Tests for using Guid as the collection's id-field. Unlike integer and string id-fields,
+/// Guid values are not incremented — a new value is generated when the caller has not set one,
+/// and a value the caller has set is kept as is.
+/// </summary>
+public class GuidIdFieldTests
+{
+    public class GuidIdModel
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; }
+
+        public Guid OtherGuid { get; set; }
+    }
+
+    public class NullableGuidIdModel
+    {
+        public Guid? Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public void InsertOne_Typed_KeepsCallerDefinedId()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        collection.InsertOne(new GuidIdModel { Id = first, Name = "Jim" });
+        collection.InsertOne(new GuidIdModel { Id = second, Name = "Barry" });
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal(first, items[0].Id);
+        Assert.Equal(second, items[1].Id);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Typed_GeneratesIdWhenEmpty()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        collection.InsertOne(new GuidIdModel { Name = "Jim" });
+        collection.InsertOne(new GuidIdModel { Name = "Barry" });
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.All(items, i => Assert.NotEqual(Guid.Empty, i.Id));
+        Assert.NotEqual(items[0].Id, items[1].Id);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertMany_Typed_GeneratesUniqueIds()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        collection.InsertMany(new[]
+        {
+            new GuidIdModel { Name = "Jim" },
+            new GuidIdModel { Name = "Barry" },
+            new GuidIdModel { Name = "Sandels" }
+        });
+
+        var ids = collection.AsQueryable().Select(e => e.Id).ToList();
+
+        Assert.Equal(3, ids.Distinct().Count());
+        Assert.DoesNotContain(Guid.Empty, ids);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void GetNextIdValue_Typed_ReturnsNewGuid()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        var emptyCollectionId = collection.GetNextIdValue();
+        Assert.IsType<Guid>(emptyCollectionId);
+        Assert.NotEqual(Guid.Empty, emptyCollectionId);
+
+        collection.InsertOne(new GuidIdModel { Name = "Jim" });
+
+        var nextId = collection.GetNextIdValue();
+        Assert.IsType<Guid>(nextId);
+        Assert.NotEqual(Guid.Empty, nextId);
+        Assert.NotEqual(collection.AsQueryable().First().Id, (Guid)nextId);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void UpdateOne_ReplaceOne_DeleteOne_Typed_WithGuidId()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        var itemId = Guid.NewGuid();
+        var secondGuid = Guid.NewGuid();
+        var thirdGuid = Guid.NewGuid();
+
+        collection.InsertOne(new GuidIdModel { Id = itemId, Name = "Jim", OtherGuid = secondGuid });
+
+        Assert.True(collection.ReplaceOne(e => e.Id == itemId, new GuidIdModel { Id = itemId, Name = "Barry", OtherGuid = secondGuid }));
+        Assert.True(collection.UpdateOne(e => e.Id == itemId, new { Name = "Sandels" }));
+        Assert.True(collection.UpdateOne(e => e.Id == itemId, new { OtherGuid = thirdGuid }));
+
+        var updated = collection.AsQueryable().Single();
+
+        Assert.Equal(itemId, updated.Id);
+        Assert.Equal("Sandels", updated.Name);
+        Assert.Equal(thirdGuid, updated.OtherGuid);
+
+        Assert.True(collection.DeleteOne(e => e.Id == itemId));
+        Assert.Empty(collection.AsQueryable());
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void ReplaceOne_Typed_WithIdValue()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        var itemId = Guid.NewGuid();
+        collection.InsertOne(new GuidIdModel { Id = itemId, Name = "Jim" });
+
+        Assert.True(collection.ReplaceOne(itemId, new GuidIdModel { Id = itemId, Name = "Barry" }));
+        Assert.Equal("Barry", collection.AsQueryable().Single().Name);
+
+        Assert.True(collection.DeleteOne(itemId));
+        Assert.Empty(collection.AsQueryable());
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public async Task InsertOneAsync_Typed_PersistsGuidId()
+    {
+        var newFilePath = UTHelpers.Up();
+
+        var store = new DataStore(newFilePath);
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        await collection.InsertOneAsync(new GuidIdModel { Name = "Jim" });
+        var inserted = collection.AsQueryable().Single();
+
+        store.Dispose();
+
+        var store2 = new DataStore(newFilePath);
+        var reloaded = store2.GetCollection<GuidIdModel>("guidIds").AsQueryable().Single();
+
+        Assert.Equal(inserted.Id, reloaded.Id);
+        Assert.NotEqual(Guid.Empty, reloaded.Id);
+
+        store2.Dispose();
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void InsertOne_Typed_BothCasingModes(bool useLowerCamelCase)
+    {
+        var newFilePath = UTHelpers.GetFullFilePath($"GuidCasing_{useLowerCamelCase}");
+        var store = new DataStore(newFilePath, useLowerCamelCase);
+
+        var collection = store.GetCollection<GuidIdModel>("guidIds");
+
+        var itemId = Guid.NewGuid();
+        collection.InsertOne(new GuidIdModel { Id = itemId, Name = "Jim" });
+        collection.InsertOne(new GuidIdModel { Name = "Barry" });
+
+        store.Dispose();
+
+        var store2 = new DataStore(newFilePath, useLowerCamelCase);
+        var items = store2.GetCollection<GuidIdModel>("guidIds").AsQueryable().ToList();
+
+        Assert.Equal(itemId, items[0].Id);
+        Assert.NotEqual(Guid.Empty, items[1].Id);
+
+        store2.Dispose();
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Typed_NullableGuidId()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<NullableGuidIdModel>("nullableGuidIds");
+
+        var itemId = Guid.NewGuid();
+        collection.InsertOne(new NullableGuidIdModel { Id = itemId, Name = "Jim" });
+        collection.InsertOne(new NullableGuidIdModel { Name = "Barry" });
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.Equal(itemId, items[0].Id);
+        Assert.NotNull(items[1].Id);
+        Assert.NotEqual(Guid.Empty, items[1].Id.Value);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Dynamic_GeneratesNewGuidWhenLastIdIsGuid()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("dynamicGuidIds");
+
+        var itemId = Guid.NewGuid();
+        collection.InsertOne(new { id = itemId, name = "Jim" });
+        collection.InsertOne(new { name = "Barry" });
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.Equal(itemId.ToString(), (string)items[0].id);
+
+        var generated = (string)items[1].id;
+        Assert.True(Guid.TryParse(generated, out var parsed));
+        Assert.NotEqual(Guid.Empty, parsed);
+        Assert.NotEqual(itemId, parsed);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void GetNextIdValue_Dynamic_StringIdIsStillIncremented()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("dynamicStringIds");
+
+        collection.InsertOne(new { id = "item1", name = "Jim" });
+
+        Assert.Equal("item2", collection.GetNextIdValue());
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Typed_StringIdWithGuidValuesGeneratesNewGuid()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<StringIdModel>("stringGuidIds");
+
+        var itemId = Guid.NewGuid();
+        collection.InsertOne(new StringIdModel { Id = itemId.ToString(), Name = "Jim" });
+        collection.InsertOne(new StringIdModel { Name = "Barry" });
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.Equal(itemId.ToString(), items[0].Id);
+        Assert.True(Guid.TryParse(items[1].Id, out var generated));
+        Assert.NotEqual(Guid.Empty, generated);
+        Assert.NotEqual(itemId, generated);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Dynamic_KeepsCallerDefinedIdFormat()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("dynamicGuidIds");
+
+        collection.InsertOne(new { id = Guid.NewGuid().ToString(), name = "Jim" });
+
+        var nonCanonicalId = "{AB6E9F13-4E33-4D2A-9C31-2B1E3C0A5F77}";
+
+        dynamic item = new System.Dynamic.ExpandoObject();
+        item.id = nonCanonicalId;
+        item.name = "Barry";
+
+        collection.InsertOne(item);
+
+        var items = collection.AsQueryable().ToList();
+
+        Assert.Equal(nonCanonicalId, (string)items[1].id);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-guid")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void InsertOne_Dynamic_GeneratesNewGuidWhenCallerIdIsNotUsable(string callerId)
+    {
+        var newFilePath = UTHelpers.Up($"DynamicGuidFallback_{callerId.Length}");
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection("dynamicGuidIds");
+
+        collection.InsertOne(new { id = Guid.NewGuid().ToString(), name = "Jim" });
+
+        dynamic item = new System.Dynamic.ExpandoObject();
+        item.id = callerId;
+        item.name = "Barry";
+
+        collection.InsertOne(item);
+
+        var inserted = (string)collection.AsQueryable().ToList()[1].id;
+
+        Assert.True(Guid.TryParse(inserted, out var generated));
+        Assert.NotEqual(Guid.Empty, generated);
+
+        store.Dispose();
+        UTHelpers.Down(newFilePath);
+    }
+
+    [Fact]
+    public void InsertOne_Typed_StringIdKeepsCallerDefinedIdFormat()
+    {
+        var newFilePath = UTHelpers.Up();
+        var store = new DataStore(newFilePath);
+
+        var collection = store.GetCollection<StringIdModel>("stringGuidIds");
+
+        collection.InsertOne(new StringIdModel { Id = Guid.NewGuid().ToString(), Name = "Jim" });
+
+        var nonCanonicalId = "AB6E9F13-4E33-4D2A-9C31-2B1E3C0A5F77";
+        collection.InsertOne(new StringIdModel { Id = nonCanonicalId, Name = "Barry" });
+
+        Assert.Equal(nonCanonicalId, collection.AsQueryable().ToList()[1].Id);
+
+        UTHelpers.Down(newFilePath);
+    }
+
+    public class StringIdModel
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
+++ b/JsonFlatFileDataStore.Test/TemporalAndIdentifierTests.cs
@@ -103,21 +103,18 @@ public class TemporalAndIdentifierTests
     }
 
     [Fact]
-    public void Guid_AsIdField_NotSupported_BehaviorPinned()
+    public void Guid_AsIdField_Supported()
     {
-        // Documented limitation: a typed model with a Guid as the key property fails on insert
-        // because the library's dynamic-dispatch path through ObjectExtensions.AddDataToField
-        // cannot set a Guid value via reflection in this code path.
-        //
-        // Migration note: STJ may or may not surface this same failure. If it does not,
-        // update this test to assert success.
+        // A typed model can use a Guid as the key property. See GuidIdFieldTests for the full behavior.
         var path = UTHelpers.GetFullFilePath($"GuidIdLim_{DateTime.UtcNow.Ticks}");
         var store = new DataStore(path);
 
         var collection = store.GetCollection<GuidIdModel>("guidIdModel");
 
-        Assert.Throws<ArgumentException>(() =>
-            collection.InsertOne(new GuidIdModel { Id = Guid.NewGuid(), Name = "X" }));
+        var id = Guid.NewGuid();
+        collection.InsertOne(new GuidIdModel { Id = id, Name = "X" });
+
+        Assert.Equal(id, collection.AsQueryable().Single().Id);
 
         store.Dispose();
         UTHelpers.Down(path);

--- a/JsonFlatFileDataStore/DocumentCollection.cs
+++ b/JsonFlatFileDataStore/DocumentCollection.cs
@@ -11,6 +11,7 @@ public class DocumentCollection<T> : IDocumentCollection<T>
 {
     private readonly string _path;
     private readonly string _idField;
+    private bool? _isGuidIdField;
     private readonly Lazy<List<T>> _data;
     private readonly Func<string, Func<List<T>, bool>, bool, Task<bool>> _commit;
     private readonly Func<T, T> _insertConvert;
@@ -381,6 +382,12 @@ public class DocumentCollection<T> : IDocumentCollection<T>
 
     private dynamic GetNextIdValue(List<T> data, T item = default(T))
     {
+        if (IsGuidIdField)
+        {
+            // Guid id-fields are not incremented, so a value that the caller has set is used as is
+            return TryGetItemGuid(item, out Guid itemGuid, out _) ? itemGuid : Guid.NewGuid();
+        }
+
         if (!data.Any())
         {
             if (item != null)
@@ -410,7 +417,68 @@ public class DocumentCollection<T> : IDocumentCollection<T>
         if (keyValue is Int64)
             return (int)keyValue + 1;
 
+        // With dynamic collections the id-field's type is only known from the stored value
+        if (IsGuidValue((object)keyValue, out Guid _))
+        {
+            if (!TryGetItemGuid(item, out Guid itemGuid, out object itemIdValue))
+                return Guid.NewGuid().ToString();
+
+            // A caller-defined value is used as is, so its original format is not lost
+            return itemIdValue as string ?? itemGuid.ToString();
+        }
+
         return ParseNextIntegerToKeyValue(keyValue.ToString());
+    }
+
+    /// <summary>
+    /// True when the collection's type has a Guid id-field. The value is resolved once,
+    /// as the collection's type and the name of the id-field don't change.
+    /// </summary>
+    private bool IsGuidIdField
+    {
+        get
+        {
+            if (_isGuidIdField is null)
+            {
+                var idFieldType = ObjectExtensions.GetFieldType<T>(_idField);
+                _isGuidIdField = idFieldType == typeof(Guid) || idFieldType == typeof(Guid?);
+            }
+
+            return _isGuidIdField.Value;
+        }
+    }
+
+    /// <summary>
+    /// Get the item's id-field value when the caller has set it to a non-empty Guid.
+    /// The value is returned both parsed and as it was stored on the item.
+    /// </summary>
+    private bool TryGetItemGuid(T item, out Guid guid, out object value)
+    {
+        guid = Guid.Empty;
+        value = null;
+
+        if (item == null)
+            return false;
+
+        // Note: GetFieldValue routes the value through ExpandoObjectConverter, which presents a Guid as a string
+        value = GetFieldValue(item, _idField);
+
+        return IsGuidValue(value, out guid) && guid != Guid.Empty;
+    }
+
+    private static bool IsGuidValue(object value, out Guid guid)
+    {
+        switch (value)
+        {
+            case Guid guidValue:
+                guid = guidValue;
+                return true;
+            case string stringValue:
+                return Guid.TryParse(stringValue, out guid);
+            default:
+                guid = Guid.Empty;
+                return false;
+        }
     }
 
     private dynamic GetFieldValue(T item, string fieldName)

--- a/JsonFlatFileDataStore/ObjectExtensions.cs
+++ b/JsonFlatFileDataStore/ObjectExtensions.cs
@@ -67,6 +67,19 @@ internal static class ObjectExtensions
                name.IndexOf("AnonymousType", StringComparison.Ordinal) > 0;
     }
 
+    /// <summary>
+    /// Get the declared type of a field. Returns null if the type doesn't have the field,
+    /// e.g. when the collection's type is dynamic.
+    /// </summary>
+    internal static Type GetFieldType<T>(string fieldName)
+    {
+        var property = typeof(T)
+                        .GetProperties()
+                        .FirstOrDefault(p => string.Equals(p.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+
+        return property?.PropertyType;
+    }
+
     internal static bool HasField<T>(T item, string idField)
     {
         var idProperty = item.GetType()

--- a/README.md
+++ b/README.md
@@ -430,11 +430,7 @@ await collection.DeleteManyAsync(e => e.City == "NY");
 
 If incrementing Id-field values are used, `GetNextIdValue` returns the next Id-field value. For integer Id-properties, the last item's value is incremented by one. For non-integer fields, the value is converted to a string and number at the end of the sting is parsed and incremented by one.
 
-> **Supported Id-field types:** integer types and `string` work as the collection key.
-> `Guid` is **not** supported as the Id property of a typed collection — inserts throw
-> at runtime. Use `int` or `string` as the key and keep the `Guid` in another field if
-> you need one per row. `Guid` is fine everywhere else (non-key fields,
-> `InsertItem`/`GetItem<Guid>` for single items).
+> **Supported Id-field types:** integer types, `string` and `Guid` work as the collection key.
 
 ```csharp
 var store = new DataStore(newFilePath, keyProperty: "myId");
@@ -451,6 +447,41 @@ var nextId = collection.GetNextIdValue();
 
 collection.InsertOne(new { myId = "hello3" });
 // nextId = "hello4"
+var nextId = collection.GetNextIdValue();
+```
+
+##### Guid Id-Fields
+
+`Guid` Id-field values are not incremented. `GetNextIdValue` returns a new `Guid` and on insert
+a new value is generated only when the item doesn't have an Id-field value yet, so an Id-field
+value that the caller has set is always kept as is.
+
+```csharp
+public class Employee
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+}
+
+var collection = store.GetCollection<Employee>();
+
+// Id is generated as it is Guid.Empty
+collection.InsertOne(new Employee { Name = "Phil" });
+
+// Id is used as is
+collection.InsertOne(new Employee { Id = Guid.NewGuid(), Name = "Raymond" });
+```
+
+When the Id-field is not declared as a `Guid` — a dynamic collection, or a `string` Id-property —
+the type is only known from the stored value. A new `Guid` is generated as a string when the
+collection's last item has an Id-field value that is a valid `Guid`, instead of incrementing the
+number at the end of the string.
+
+```csharp
+var collection = store.GetCollection("employee");
+
+collection.InsertOne(new { id = Guid.NewGuid(), name = "Phil" });
+// nextId is a new Guid as a string
 var nextId = collection.GetNextIdValue();
 ```
 


### PR DESCRIPTION
Implements #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `Guid` and nullable `Guid` collection IDs.
  * Empty IDs now receive generated GUIDs, while provided IDs are preserved.
  * String-based collections can generate GUID values when appropriate.
  * GUID ID support works with typed and dynamic collections, including asynchronous operations.

* **Documentation**
  * Updated usage guidance and behavior details for GUID collection IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->